### PR TITLE
Improve CLI Documentation formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,14 @@
 
 <a href="https://www.buymeacoffee.com/master_of_zen" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
-Av1an is a video encoding framework. It can increase your encoding speed and improve cpu utilization by running multiple encoder processes in parallel. Target quality, VMAF plotting, and more, available to take advantage for video encoding.
+Av1an is a video encoding framework. It can increase your encoding speed and improve cpu utilization by running multiple encoder processes in parallel. Key features include [Target Quality](https://rust-av.github.io/Av1an/Features/TargetQuality), [VMAF plotting](https://rust-av.github.io/Av1an/Cli/vmaf), and more available to improve video encoding.
 
 For help with av1an, please reach out to us on [Discord](https://discord.gg/Ar8MvJh) or file a GitHub issue.
-
-# [**Av1an Book**](https://master-of-zen.github.io/Av1an/)
 
 ## Features
 
 - Hyper-scalable video encoding
-- [Target Quality mode](https://master-of-zen.github.io/Av1an/Features/TargetQuality.html), using VMAF control encoders rate control to achieve the desired video quality
+- [Target Quality mode](https://rust-av.github.io/Av1an/Cli/target_quality), using VMAF control encoders rate control to achieve the desired video quality
 - [VapourSynth](http://www.vapoursynth.com) script support
 - Cancel and resume encoding without loss of progress
 - Minimal and clean CLI
@@ -27,13 +25,16 @@ For help with av1an, please reach out to us on [Discord](https://discord.gg/Ar8M
 
 ## Usage
 
-For complete reference, refer to [CLI](/docs/CLI.md)
-or run `av1an --help`
+Av1an is a command-line application that can run on Windows, Linux, and macOS. See the [Installation](#installation) section below for details on how to install it.
+
+For a complete reference, refer to our [documentation](https://rust-av.github.io/Av1an/) or run `av1an --help`.
+
+### Examples
 
 Encode a video file with the default parameters:
 
 ```sh
-av1an -i input.mkv
+av1an -i input.mkv -o output.mkv
 ```
 
 Or use a VapourSynth script and custom parameters:
@@ -57,9 +58,9 @@ Note that Av1an requires the executable encoder. If you use a package manager to
 
 ## Installation
 
-av1an can be installed from package managers, cargo.io, or compliled manually. There are also pre-built [Docker images](/site/src/docker.md) which include all dependencies and are frequently updated.
+Av1an can be installed from package managers, cargo.io, or [compiled manually](https://rust-av.github.io/Av1an/compiling). There are also pre-built [Docker images](/site/src/docker.md) which include all dependencies and are frequently updated.
 
-For Windows users, prebuilt binaries are also included in every [release](https://github.com/master-of-zen/Av1an/releases), and a [nightly build](https://github.com/master-of-zen/Av1an/releases/tag/latest) of the current `master` branch is also available.
+For Windows users, prebuilt binaries are also included in every [release](https://github.com/rust-av/Av1an/releases), and a [nightly build](https://github.com/rust-av/Av1an/releases/tag/latest) of the current `master` branch is also available.
 
 ### Package managers
 
@@ -78,15 +79,15 @@ Optional:
 
 - [L-SMASH](https://github.com/HomeOfAviSynthPlusEvolution/L-SMASH-Works) VapourSynth plugin for better chunking (recommended)
 - [DGDecNV](https://www.rationalqm.us/dgdecnv/dgdecnv.html) Vapoursynth plugin for very fast and accurate chunking, `dgindexnv` executable needs to be present in system path and an NVIDIA GPU with CUVID 
-- [ffms2](https://github.com/FFMS/ffms2) VapourSynth plugin for better chunking
-- [bestsource](https://github.com/vapoursynth/bestsource) Vapoursynth plugin for slow but accurate chunking
+- [FFMS2](https://github.com/FFMS/ffms2) VapourSynth plugin for better chunking
+- [BestSource](https://github.com/vapoursynth/bestsource) Vapoursynth plugin for slow but accurate chunking
 - [mkvmerge](https://mkvtoolnix.download/) to use mkvmerge instead of FFmpeg for file concatenation
 - [VMAF](https://github.com/Netflix/vmaf) to calculate VMAF scores and to use [target quality mode](site/src/Features/TargetQuality.md)
 
 ### VapourSynth plugins on Windows
 
-If you want to install the L-SMASH or ffms2 plugins and are on Windows, then you have [two installation options](http://vapoursynth.com/doc/installation.html#plugins-and-scripts). The easiest way is using the included plugin script:
+If you want to install the L-SMASH, FFMS2, or BestSource plugins and are on Windows, then you have [two installation options](http://vapoursynth.com/doc/installation.html#plugins-and-scripts). The easiest way is using the included plugin script:
 
 1. Open your VapourSynth installation directory
 2. Open a command prompt or PowerShell window via Shift + Right click
-3. Run `python3 vsrepo.py install lsmas ffms2`
+3. Run `python3 vsrepo.py install lsmas ffms2 bs`

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -299,7 +299,7 @@ pub struct CliOpts {
   /// to 0 to disable adding extra splits.
   #[clap(short = 'x', long, help_heading = "Scene Detection")]
   pub extra_split: Option<usize>,
-  
+
   /// Maximum scene length, in seconds
   ///
   /// If both frames and seconds are specified, then the number of frames will take priority.

--- a/site/src/Cli/encoding.md
+++ b/site/src/Cli/encoding.md
@@ -1,202 +1,310 @@
 # Encoding
 
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[Encoder](#encoder--e---encoder) | `-e`, `--encoder` | `ENCODER` | `aom`
+[Video Parameters](#video-parameters--v---video-params) | `-v`, `--video-params` | String List | Based on Encoder
+[Passes](#passes--p---passes) | `-p`, `--passes` | Integer | 1
+[Tile Auto](#tile-auto---tile-auto) | `--tile-auto` || 
+[FFmpeg Parameters](#ffmpeg-filter-arguments--f---ffmpeg) | `-f`, `--ffmpeg` | String |
+[Audio Parameters](#audio-parameters--a---audio-params) | `-a`, `--audio-params` | String |
+[Ignore Frame Mismatch](#ignore-frame-mismatch---ignore-frame-mismatch) | `--ignore-frame-mismatch` | 
+[Chunk Method](#chunk-method--m---chunk-method) | `-m`, `--chunk-method` | `CHUNK_METHOD` | `lsmash`
+[Chunk Order](#chunk-order---chunk-order) | `--chunk-order` | `CHUNK_ORDER` | `long-to-short`
+[Photon Noise](#photon-noise---photon-noise) | `--photon-noise` | Integer |
+[Chroma Noise](#chroma-noise---chroma-noise) | `--chroma-noise` || 
+[Photon Noise Width](#photon-noise-width---photon-noise-width) |`--photon-noise-width` | Integer |
+[Photon Noise Height](#photon-noise-height---photon-noise-height) | `--photon-noise-height` | Integer |
+[Concatenation Method](#concatenation-method--c---concat) | `-c`, `--concat` | `CONCAT` | `ffmpeg`
+[Pixel Format](#pixel-format---pix-format) | `--pix-format` | `PIX_FORMAT` | `yuv420p10le`
+[Zones](#zones---zones) | `-z`, `--zones` | Path | 
+
+## Encoder `-e`, `--encoder`
+
+Video encoder to use.
+
+### Possible Values
+
+* `aom` - [aomenc](https://aomedia.googlesource.com/aom/)
+* `rav1e` - [rav1e](https://github.com/xiph/rav1e)
+* `vpx` - [vpxenc](https://chromium.googlesource.com/webm/libvpx/)
+* `svt-av1` - [SvtAv1EncApp](https://gitlab.com/AOMediaCodec/SVT-AV1)
+* `x264` - [x264](https://www.videolan.org/developers/x264.html)
+* `x265` - [x265](https://www.videolan.org/developers/x265.html)
+
+### Default
+
+If not specified, `aom` will be used.
+
+## Video Parameters `-v`, `--video-params`
+
+Parameters for video encoder.
+
+These parameters are for the encoder binary directly, so the FFmpeg syntax cannot be used. For example, CRF is specified in ffmpeg via `-crf <CRF>`, but the x264 binary takes this value with double dashes, as in `--crf <CRF>`. See the `--help` output of each encoder for a list of valid options. This list of parameters will be merged into Av1an's default set of encoder parameters unless `--no-defaults` is specified.
+
+## Passes `-p`, `--passes`
+
+Number of encoder passes.
+
+Two-pass mode is used by default for `aom` and `vpx`. Unlike other encoders which two-pass mode is used for more accurate VBR rate control, `aom` and `vpx` benefit from two-pass mode even with constant quality mode.
+
+When using `aom` or `vpx` with RT mode (`--rt`), one-pass mode is always used regardless of the value specified by this flag (as RT mode in `aom` and `vpx` only supports one-pass encoding).
+
+### Possible Values
+
+Can be one of the following integers: `1` or `2`.
+
+### Default
+
+If not specified, `1` is used unless encoding with `aom` or `vpx` without RT mode (`--rt`), in which case `2` is used.
+
+## Tile Auto `--tile-auto`
+
+Estimate tile count based on resolution, and set encoder parameters, if applicable.
+
+## FFmpeg Filter Arguments `-f`, `--ffmpeg`
+
+Video filter arguments (FFmpeg syntax).
+
+### Possible Values
+
+Any of the valid FFmpeg [Video Filter Options](https://ffmpeg.org/ffmpeg.html#Video-Options).
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv -f "-vf crop=100:100:100:100"` - Crops the video by 100 pixels from the top, left, bottom, and right
+* `> av1an -i input.mkv -o output.mkv -f "-vf scale=1920:1080"` - Scales the video to 1920x1080
+
+
+## Audio Parameters `-a`, `--audio-params`
+
+Audio encoding parameters (FFmpeg syntax).
+
+Do not use FFmpeg's `-map` syntax with this option. Instead, use the colon syntax ([Stream specifiers](https://ffmpeg.org/ffmpeg.html#Stream-specifiers-1)) with each parameter you specify.
+
+Subtitles are always copied by default.
+
+### Possible Values
+
+Any of the valid FFmpeg [Audio Options](https://ffmpeg.org/ffmpeg.html#Audio-Options).
+
+### Default
+
+If not specified, `-c:a copy` is used.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv -a "-c:a libopus -b:a 128k"` - Encodes all audio tracks with [libopus][ffmpeg-libopus] at 128k
+* `> av1an -i input.mkv -o output.mkv --audio-params "-c:a:0 libopus -b:a:0 128k -c:a:1 aac -ac:a:1 1 -b:a:1 24k"` - Encodes the first audio track with [libopus][ffmpeg-libopus] at 128k and the second audio track with [aac][ffmpeg-aac] at 24k and downmixed to a single channel
+
+## Ignore Frame Mismatch `--ignore-frame-mismatch`
+
+Ignore any detected mismatch between scene frame count and encoder frame count
+
+## Chunk Method `-m`, `--chunk-method`
+
+Method used for piping exact ranges of frames to the encoder.
+
+Some methods require external VapourSynth plugins to be installed. The rest only require FFmpeg.
+
+### Possible Values
+
+* `lsmash` - [L-SMASH-Works](https://github.com/HomeOfAviSynthPlusEvolution/L-SMASH-Works)
+  * Requires VapourSynth plugin
+  * Generally the best and most accurate method
+  * Does not require intermediate files
+  * Errors generally only occur if the input file itself is broken (for example, if the video bitstream is invalid in some way, video players usually try to recover from the errors as much as possible even if it results in visible artifacts, while lsmash will instead throw an error)
+* `ffms2` - [FFmpegSource](https://github.com/FFMS/ffms2)
+  * Requires VapourSynth plugin
+  * Accurate
+  * Slightly faster than lsmash for y4m input
+  * Does not require intermediate files
+  * Can sometimes have bizarre bugs that are not present in lsmash (that can cause artifacts in the piped output)
+* `dgdecnv` - [DGDecNV](https://www.rationalqm.us/dgdecnv/dgdecnv.html)
+  * Requires VapourSynth plugin
+  * Requires `dgindexnv` to be present in system path
+  * Requires an NVIDIA GPU that supports CUDA video decoding
+  * Very fast but only decodes AVC, HEVC, MPEG-2, and VC1
+* `bestsource` - [BestSource](https://github.com/vapoursynth/bestsource)
+  * Requires VapourSynth plugin
+  * Slow but most accurate
+  * Linearly decodes input files
+  * Does not require intermediate files
+* `hybrid` - Hybrid (Segment + Select)
+  * Requires FFmpeg
+  * Usually accurate but requires intermediate files (which can be large)
+  * Avoids decoding irrelevant frames by seeking to the first keyframe before the requested frame and decoding only a (usually very small) number of irrelevant frames until relevant frames are decoded and piped to the encoder
+* `select` - Select
+  * Requires FFmpeg
+  * Extremely slow, but accurate
+  * Does not require intermediate files
+  * Decodes from the first frame to the requested frame, without skipping irrelevant frames (causing quadratic decoding complexity)
+* `segment` - Segment
+  * Requires FFmpeg
+  * Create chunks based on keyframes in the source
+  * Not frame exact, as it can only split on keyframes in the source
+  * Requires intermediate files (which can be large)
+
+### Default
+
+If not specified, the first available method is used in this order:
+
+* `lsmash`
+* `ffms2`
+* `dgdecnv`
+* `bestsource`
+* `hybrid`
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv -m lsmash` - Use L-SMASH-Works for chunking
+* `> av1an -i input.mkv -o output.mkv -m ffms2` - Use FFmpegSource for chunking
+* `> av1an -i input.mkv -o output.mkv -m hybrid` - Use hybrid for chunking
+
+## Chunk Order `--chunk-order`
+
+The order in which Av1an will encode chunks.
+
+### Possible Values
+
+* `long-to-short` - The longest chunks will be encoded first. This method results in the smallest amount of time with idle cores, as the encode will not be waiting on a very long chunk to finish at the end of the encode after all other chunks have finished.
+* `short-to-long` - The shortest chunks will be encoded first.
+* `sequential` - The chunks will be encoded in the order they appear in the video.
+* `random` - The chunks will be encoded in a random order. This will provide a more accurate estimated filesize sooner in the encode.
+
+### Default
+
+If not specified, `long-to-short` is used.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --chunk-order short-to-long` - Encodes the shortest chunks first
+* `> av1an -i input.mkv -o output.mkv --chunk-order random` - Encodes the chunks in a random order
+
+## Photon Noise `--photon-noise`
+
+Generates a photon noise table and applies it using grain synthesis.
+
+Photon noise tables are more visually pleasing than the film grain generated by aomenc, and provide a consistent level of grain regardless of the level of grain in the source. Strength values correlate to ISO values, e.g. `1` = ISO 100, and `64` = ISO 6400. This option currently only supports aomenc, rav1e, and SvtAv1EncApp.
+
+An encoder's grain synthesis will still work without using this option, by specifying the correct parameter to the encoder. However, the two should not be used together, and specifying this option will disable or overwrite the encoder's internal grain synthesis.
+
+### Possible Values
+
+Can be any integer from `0` to `64`.
+
+### Default
+
+If not specified, `0` is used.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --photon-noise 1` - Applies a ISO 100 photon noise table
+* `> av1an -i input.mkv -o output.mkv --photon-noise 12` - Applies a ISO 1200 photon noise table
+
+## Chroma Noise `--chroma-noise`
+
+Adds chroma grain synthesis to the grain table generated by `--photon-noise`.
+
+## Photon Noise Width `--photon-noise-width`
+
+Manually set the width for the photon noise table.
+
+### Possible Values
+
+Can be any positive integer.
+
+## Photon Noise Height `--photon-noise-height`
+
+Manually set the height for the photon noise table.
+
+### Possible Values
+
+Can be any positive integer.
+
+## Concatenation Method `-c`, `--concat`
+
+Determines method used for concatenating encoded chunks and audio into output file.
+
+### Possible Values
+
+* `ffmpeg` - FFmpeg
+  * Unfortunately, ffmpeg sometimes produces file with partially broken audio seeking, so `mkvmerge` should generally be preferred if available. FFmpeg concatenation also produces broken files with the `--enable-keyframe filtering=2` option in aomenc, so it is disabled if that option is used. However, FFmpeg can mux into formats other than Matroska (`.mkv`), such as WebM. To output WebM, use a `.webm` extension in the output file.
+* `mkvmerge` - Matroska
+  * Generally the best concatenation method (as it does not have either of the aforementioned issues that ffmpeg has), but can only produce matroska (.mkv) files. Requires mkvmerge to be installed.
+* `ivf` - IVF
+  * Experimental concatenation method implemented in Av1an itself to concatenate to an IVF file (which only supports VP8, VP9, and AV1, and does not support audio).
+
+### Default
+
+If not specified, `ffmpeg` is used.
+
+## Pixel Format `--pix-format`
+
+FFmpeg pixel format to use when encoding.
+
+### Possible Values
+
+Any valid pixel format name. See [FFmpeg](https://www.ffmpeg.org/doxygen/0.11/pixfmt_8h.html#60883d4958a60b91661e97027a85072a) for a full list.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv` - Use YUV420P10LE by default
+* `> av1an -i input.mkv -o output.mkv --pix-format yuv420p` - Use YUV420P
+* `> av1an -i input.mkv -o output.mkv --pix-format yuv444p` - Use YUV444P
+
+### Default
+
+If not specified, `yuv420p10le` is used.
+
+## Zones `--zones`
+
+Path to a file specifying zones within the video with differing encoder settings.
+
+### Possible Values
+
+The zones file should include one zone per line, with each arg within a zone separated by spaces. No quotes or escaping are needed around the encoder args, as these are assumed to be the last argument.
+
+The zone args on each line should be in this order:
+
 ```
--e, --encoder <ENCODER>
-		Video encoder to use
-
-		[default: aom]
-		[possible values: aom, rav1e, vpx, svt-av1, x264, x265]
-
--v, --video-params <VIDEO_PARAMS>
-		Parameters for video encoder
-
-		These parameters are for the encoder binary directly, so the ffmpeg syntax cannot be
-		used. For example, CRF is specified in ffmpeg via "-crf <crf>", but the x264 binary
-		takes this value with double dashes, as in "--crf <crf>". See the --help output of each
-		encoder for a list of valid options. This list of parameters will be merged into
-		Av1an's default set of encoder parameters.
-
--p, --passes <PASSES>
-		Number of encoder passes
-
-		Since aom and vpx benefit from two-pass mode even with constant quality mode (unlike
-		other encoders in which two-pass mode is used for more accurate VBR rate control), two-
-		pass mode is used by default for these encoders.
-
-		When using aom or vpx with RT mode (--rt), one-pass mode is always used regardless
-		of the value specified by this flag (as RT mode in aom and vpx only supports one-pass
-		encoding).
-
-		[possible values: 1, 2]
-
---tile-auto
-		Estimate tile count based on resolution, and set encoder parameters, if applicable.
-
--a, --audio-params <AUDIO_PARAMS>
-		Audio encoding parameters (ffmpeg syntax)
-
-		If not specified, "-c:a copy" is used.
-
-		Do not use ffmpeg's -map syntax with this option. Instead, use the colon syntax with
-		each parameter you specify.
-
-		Subtitles are always copied by default.
-
-		Example to encode all audio tracks with libopus at 128k:
-
-		-a="-c:a libopus -b:a 128k"
-
-		Example to encode the first audio track with libopus at 128k, and the second audio track
-		with aac at 24k, where only the second track is downmixed to a single channel:
-
-		-a="-c:a:0 libopus -b:a:0 128k -c:a:1 aac -ac:a:1 1 -b:a:1 24k"
-
--f, --ffmpeg <FFMPEG_FILTER_ARGS>
-		FFmpeg filter options
-
--m, --chunk-method <CHUNK_METHOD>
-		Method used for piping exact ranges of frames to the encoder
-
-		Methods that require an external vapoursynth plugin:
-
-		lsmash - Generally the best and most accurate method. Does not require intermediate
-		files. Errors generally only occur if the input file itself is broken (for example,
-		if the video bitstream is invalid in some way, video players usually try to recover
-		from the errors as much as possible even if it results in visible artifacts, while
-		lsmash will instead throw an error). Requires the lsmashsource vapoursynth plugin to
-		be installed.
-
-		ffms2 - Accurate and does not require intermediate files. Can sometimes have bizarre
-		bugs that are not present in lsmash (that can cause artifacts in the piped output).
-		Slightly faster than lsmash for y4m input. Requires the ffms2 vapoursynth plugin to
-		be installed.
-
-        dgdecnv - Very fast, but only decodes AVC, HEVC, MPEG-2, and VC1. Does not require intermediate files.
-	    Requires dgindexnv to be present in system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv vapoursynth plugin
-        to be installed.
-
-	    bestsource - Very slow but accurate. Linearly decodes input files. Does not require intermediate files, requires the BestSource vapoursynth plugin
-        to be installed.
-
-		Methods that only require ffmpeg:
-
-		hybrid - Uses a combination of segment and select. Usually accurate but requires
-		intermediate files (which can be large). Avoids decoding irrelevant frames by seeking to
-		the first keyframe before the requested frame and decoding only a (usually very small)
-		number of irrelevant frames until relevant frames are decoded and piped to the encoder.
-
-		select - Extremely slow, but accurate. Does not require intermediate files. Decodes
-		from the first frame to the requested frame, without skipping irrelevant frames (causing
-		quadratic decoding complexity).
-
-		segment - Create chunks based on keyframes in the source. Not frame exact, as it can
-		only split on keyframes in the source. Requires intermediate files (which can be large).
-
-		Default: lsmash (if available), otherwise ffms2 (if available), otherwise DGDecNV (if available), otherwise bestsource (if available), otherwise hybrid.
-
-		[possible values: segment, select, ffms2, lsmash, dgdecnv, bestsource, hybrid]
-
-	--chunk-order <CHUNK_ORDER>
-		The order in which av1an will encode chunks
-
-		Available methods:
-
-		long-to-short - The longest chunks will be encoded first. This method results in the
-		smallest amount of time with idle cores, as the encode will not be waiting on a very
-		long chunk to finish at the end of the encode after all other chunks have finished.
-
-		short-to-long - The shortest chunks will be encoded first.
-
-		sequential - The chunks will be encoded in the order they appear in the video.
-
-		random - The chunks will be encoded in a random order. This will provide a more accurate
-		estimated filesize sooner in the encode.
-
-		[default: long-to-short]
-		[possible values: long-to-short, short-to-long, sequential, random]
-
-	--photon-noise <PHOTON_NOISE>
-		Generates a photon noise table and applies it using grain synthesis [strength: 0-64]
-		(disabled by default)
-
-		Photon noise tables are more visually pleasing than the film grain generated by aomenc,
-		and provide a consistent level of grain regardless of the level of grain in the source.
-		Strength values correlate to ISO values, e.g. 1 = ISO 100, and 64 = ISO 6400. This
-		option currently only supports aomenc and rav1e.
-
-		An encoder's grain synthesis will still work without using this option, by specifying
-		the correct parameter to the encoder. However, the two should not be used together, and
-		specifying this option will disable the encoder's internal grain synthesis.
-
--c, --concat <CONCAT>
-		Determines method used for concatenating encoded chunks and audio into output file
-
-		ffmpeg - Uses ffmpeg for concatenation. Unfortunately, ffmpeg sometimes produces files
-		with partially broken audio seeking, so mkvmerge should generally be preferred if
-		available. ffmpeg concatenation also produces broken files with the --enable-keyframe-
-		filtering=2 option in aomenc, so it is disabled if that option is used. However, ffmpeg
-		can mux into formats other than matroska (.mkv), such as WebM. To output WebM, use
-		a .webm extension in the output file.
-
-		mkvmerge - Generally the best concatenation method (as it does not have either of the
-		aforementioned issues that ffmpeg has), but can only produce matroska (.mkv) files.
-		Requires mkvmerge to be installed.
-
-		ivf - Experimental concatenation method implemented in av1an itself to concatenate to an
-		ivf file (which only supports VP8, VP9, and AV1, and does not support audio).
-
-		[default: ffmpeg]
-		[possible values: ffmpeg, mkvmerge, ivf]
-
-	--pix-format <PIX_FORMAT>
-		FFmpeg pixel format
-
-		[default: yuv420p10le]
-
-	--zones <ZONES>
-		Path to a file specifying zones within the video with differing encoder settings.
-
-		The zones file should include one zone per line,
-		with each arg within a zone space-separated.
-		No quotes or escaping are needed around the encoder args,
-		as these are assumed to be the last argument.
-
-		The zone args on each line should be in this order:
-
-		```
-		start_frame end_frame encoder reset(opt) video_params
-		```
-
-		For example:
-
-		```
-		136 169 aom --photon-noise 4 --cq-level=32
-		169 1330 rav1e reset -s 3 -q 42
-		```
-
-		Example line 1 will encode frames 136-168 using aomenc
-		with the argument `--cq-level=32` and enable av1an's `--photon-noise` option.
-		Note that the end frame number is *exclusive*.
-		The start and end frame will both be forced to be scenecuts.
-		Additional scene detection will still be applied within the zones.
-		`-1` can be used to refer to the last frame in the video.
-
-		The default behavior as shown on line 1 is to preserve
-		any options passed to `--video-params` or `--photon-noise`
-		in av1an, and append or overwrite the additional zone settings.
-
-		Example line 2 will encode frames 169-1329 using rav1e.
-		The `reset` keyword instructs av1an to ignore any settings
-		which affect the encoder, and use only the parameters from this zone.
-
-		For segments where no zone is specified,
-		the settings passed to av1an itself will be used.
-
-		The video params which may be specified include any parameters
-		that are allowed by the encoder, as well as the following av1an options:
-
-		- `-x`/`--extra-split`
-		- `--min-scene-len`
-		- `--passes`
-		- `--photon-noise` (aomenc/rav1e only)
+start_frame end_frame encoder reset(opt) video_params
 ```
+
+`start_frame` is inclusive and `end_frame` is exclusive and both will be used as scene cuts. Additional scene detection will still be applied within each zone. `-1` can be used to indicate the end of the video.
+
+The `reset` keyword instructs Av1an to ignore any settings which affect the encoder, and use only the parameters from this zone.
+
+The video parameters which may be specified include any parameters that are allowed by the encoder, as well as the following Av1an options:
+
+* [Extra Split Frames](./scene_detection.md#extra-split-frames--x---extra-split) `-x`, `--extra-split`
+* [Minimum Scene Length](./scene_detection.md#minimum-scene-length---min-scene-len) `--min-scene-len`
+* [Passes](#passes--p---passes) `-p`, `--passes`
+* [Photon Noise](#photon-noise---photon-noise) `--photon-noise` (aomenc/rav1e/SvtAv1EncApp only)
+* [Photon Noise Width](#photon-noise-width---photon-noise-width) `--photon-noise-width` (aomenc/rav1e/SvtAv1EncApp only)
+* [Photon Noise Height](#photon-noise-height---photon-noise-height) `--photon-noise-height` (aomenc/rav1e/SvtAv1EncApp only)
+* [Chroma Noise](#chroma-noise---chroma-noise) `--chroma-noise` (aomenc/rav1e/SvtAv1EncApp only)
+
+For segments where no zone is specified, the settings passed to av1an itself will be used.
+
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --zones zones.txt` - Use the zones file `./zones.txt`
+* `> av1an -i input.mkv -o output.mkv --zones C:\custom\configuration\zones.txt` - Use the zones file `C:\custom\configuration\zones.txt`
+
+#### `./zones.txt`:
+```
+136 169 aom --photon-noise 4 --cq-level=32
+169 1330 rav1e reset -s 3 -q 42
+```
+
+Line 1 will encode frames 136-168 using aomenc with the argument `--cq-level=32` and enable Av1an's `--photon-noise` option.
+
+The default behavior as shown on line 1 is to preserve any options passed to `--video-params` or `--photon-noise`
+in Av1an, and append or overwrite the additional zone settings.
+
+Line 2 will encode frames 169-1329 using rav1e with only the arguments `-s 3 -q 42`.
+
+[ffmpeg-libopus]: https://ffmpeg.org/ffmpeg-codecs.html#libopus-1
+[ffmpeg-aac]: https://ffmpeg.org/ffmpeg-codecs.html#aac

--- a/site/src/Cli/general.md
+++ b/site/src/Cli/general.md
@@ -1,96 +1,206 @@
+# General
 
-## General
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[Input](#input--i) | `-i` | Path
+[Output](#output--o) | `-o` | Path
+[Temporary](#temporary---temp) | `--temp` | Path | Input file name hash
+[Quiet](#quiet--q---quiet) | `-q` | 
+[Verbose](#verbose---verbose) | `--verbose` | 
+[Log File](#log-file--l---log-file) | `-l`, `--log-file` | Path | `./logs/av1an.log`
+[Log Level](#log-level---log-level) | `--log-level` | `LOG_LEVEL` | `debug`
+[Resume](#resume---resume) | `--resume` | 
+[Keep](#keep--k---keep) | `-k`, `--keep` | 
+[Force](#force---force) | `--force` | 
+[No Defaults](#no-defaults---no-defaults) | `--no-defaults` | 
+[Overwrite](#overwrite--y) | `-y` | 
+[Never Overwrite](#never-overwrite--n) | `-n` | 
+[Max Tries](#max-tries---max-tries) | `--max-tries` | Integer | 3
+[Thread Affinity](#thread-affinity---set-thread-affinity) | `--set-thread-affinity` | Integer | 
+[Scaler](#scaler---scaler) | `--scaler` | `SCALER` | `bicubic`
+[VSPipe Arguments](#vspipe-arguments---vspipe-args) | `--vspipe-args` | String List | 
+[Help](#help--h---help) | `-h`, `--help` | 
+[Version](#version--v---version) | `-V`, `--version` | 
 
-```
--i <INPUT>
-		Input file to encode
+## Input `-i`
 
-		Can be a video or vapoursynth (.py, .vpy) script.
+Input file to encode.
 
--o <OUTPUT_FILE>
-		Video output file
+Can be a video or a VapourSynth (`.py`, `.vpy`) script.
 
-	--temp <TEMP>
-		Temporary directory to use
+### Examples
 
-		If not specified, the temporary directory name is a hash of the input file name.
+* `> av1an -i ./input.mkv -o output.mkv`
+* `> av1an -i C:\Videos\input.mp4 -o output.mkv`
+* `> av1an -i /home/videos/vapoursynth/script.vpy -o output.mkv`
+* `> av1an -i ./script.py -o output.mkv`
 
--q, --quiet
-		Disable printing progress to the terminal
+## Output `-o`
 
-	--verbose
-		Print extra progress info and stats to terminal
+Video output file.
 
--l, --log-file <LOG_FILE>
-		Log file location [default: <temp dir>/log.log]
+### Examples
 
-	--log-level <LOG_LEVEL>
-		Set log level for log file (does not affect command-line log level)
+* `> av1an -i input.mkv -o C:\Encodes\output.mkv`
+* `> av1an -i input.mkv -o output.mkv`
+* `> av1an -i input.mkv -o /home/videos/av1an/done.mkv`
 
-		error: Designates very serious errors.
+## Temporary `--temp`
 
-		warn: Designates hazardous situations.
+Temporary directory to use.
 
-		info: Designates useful information.
+### Default
 
-		debug: Designates lower priority information.
+If not specified, the temporary directory name is a hash of the input file name.
 
-		trace: Designates very low priority, often extremely verbose, information. Includes
-		rav1e scenechange decision info.
+### Examples
 
-		[default: DEBUG]
-		[possible values: error, warn, info, debug, trace]
+* `> av1an -i input.mkv -o output.mkv` - Creates temporary directory `./.bf937a7/`
+* `> av1an -i input.mkv -o output.mkv --temp temporary` - Creates temporary directory `./temporary/`
+* `> av1an -i input.mkv -o output.mkv --temp C:\tmp\av1an` - Creates temporary directory `C:\tmp\av1an\`
 
--r, --resume
-		Resume previous session from temporary directory
+## Quiet `-q`, `--quiet`
 
--k, --keep
-		Do not delete the temporary folder after encoding has finished
+Disable printing progress to the terminal.
 
-	--force
-		Do not check if the encoder arguments specified by -v/--video-params are valid.
+## Verbose `--verbose`
 
-	--no-defaults
-		Do not include Av1an's default set of encoder parameters.
+Print extra progress info and stats to the terminal.
 
--y
-		Overwrite output file, without confirmation
+## Log File `-l`, `--log-file`
 
--n
-		Never overwrite output file, without confirmation
+Log file location under `./logs`.
 
-	--max-tries <MAX_TRIES>
-		Maximum number of chunk restarts for an encode
+Must be a relative path. Prepending with `./logs` is optional.
 
-		[default: 3]
+### Default
 
--w, --workers <WORKERS>
-		Number of workers to spawn [0 = automatic]
+If not specified, logs to `./logs/av1an.log.{DATE}` where `{DATE}` is the current date in [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
 
-		[default: 0]
+### Examples
 
-	--set-thread-affinity <SET_THREAD_AFFINITY>
-		Pin each worker to a specific set of threads of this size (disabled by default)
+* `> av1an -i input.mkv -o output.mkv` - Logs to `./logs/av1an.log.2020-1-10`
+* `> av1an -i input.mkv -o output.mkv -l log.txt` - Logs to `./logs/log.txt`
+* `> av1an -i input.mkv -o output.mkv --log-file ./today/1.log` - Logs to `./logs/today/1.log`
 
-		This is currently only supported on Linux and Windows, and does nothing on unsupported
-		platforms. Leaving this option unspecified allows the OS to schedule all processes
-		spawned.
+## Log Level `--log-level`
 
-	--scaler <SCALER>
-		Scaler used for scene detection (if --sc-downscale-height XXXX is used) and VMAF
-        calculation
+Set log level for log file (does not affect command-line log level)
 
-		Valid scalers are based on the scalers available in ffmpeg, including lanczos[1-9] with [1-9]
-        defining the width of the lanczos scaler.
+### Possible Values
 
-	--vspipe-args <VSPIPE_ARGS>
-		Pass python argument(s) to the script environment
+* `error`: Designates very serious errors.
+* `warn`: Designates hazardous situations.
+* `info`: Designates useful information.
+* `debug`: Designates lower priority information.
+* `trace`: Designates very low priority, often extremely verbose, information. Includes rav1e scenechange decision info.
 
-		Example: --vspipe-args "message=fluffy kittens" "head=empty"
+### Default
 
--h, --help
-		Print help information
+If not specified, log level is set to `debug`.
 
--V, --version
-		Print version information
-```
+## Resume `--resume`
+
+Resume previous session from temporary directory.
+
+## Keep `-k`, `--keep`
+
+Do not delete the temporary folder after encoding has finished
+
+Necessary for resuming a session.
+
+## Force `--force`
+
+Do not check if the encoder arguments specified by `-v`/`--video-params` are valid.
+
+## No Defaults `--no-defaults`
+
+Do not include Av1an's default set of encoder parameters.
+
+## Overwrite `-y`
+
+Overwrite output file, without confirmation
+
+## Never Overwrite `-n`
+
+Never overwrite output file, without confirmation
+
+## Max Tries `--max-tries`
+
+Maximum number of chunk restarts for an encode.
+
+### Possible Values
+
+Can be an integer greater than or equal to `1`.
+
+### Default
+
+If not specified, max tries is set to `3`.
+
+## Workers `-w`, `--workers`
+
+Number of workers to spawn.
+
+### Default
+
+If not specified or set to `0`, the number of workers is automatically determined.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv` - Spawns workers automatically
+* `> av1an -i input.mkv -o output.mkv -w 4` - Spawns 4 workers
+* `> av1an -i input.mkv -o output.mkv --workers 2` - Spawns 2 workers
+
+## Thread Affinity `--set-thread-affinity`
+
+Pin each worker to a specific set number of threads.
+
+This is currently only supported on Linux and Windows, and does nothing on unsupported platforms. Leaving this option unspecified allows the OS to schedule all processes spawned.
+
+### Possible Values
+
+Can be an integer greater than or equal to `1`.
+
+### Default
+
+If not specified, thread affinity is disabled and the OS will schedule all processes spawned.
+
+## Scaler `--scaler`
+
+Scaler used for scene detection when downscaling (`--sc-downscale-height`) or for VMAF calculation
+
+### Possible Values
+
+Valid scalers are based on the scalers available in [FFmpeg](https://ffmpeg.org/ffmpeg-scaler.html#toc-Scaler-Options), including `lanczos[1-9]` with `[1-9]` defining the width of the lanczos scaler.
+
+### Default
+
+If not specified, the scaler is set to `bicubic`.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --sc-downscale-height 720 --scaler bilinear` - Downscale to 720p using bilinear scaling
+* `> av1an -i input.mkv -o output.mkv --sc-downscale-height 540 --scaler lanczos3` - Downscale to 540p using lanczos3
+
+## VSPipe Arguments `--vspipe-args`
+
+Additional arguments to pass to vspipe.
+
+Only applicable when using VapourSynth chunking methods (`--chunk-method`) such as lsmash or ffms2 or when the input is a VapourSynth script.
+
+### Possible Values
+
+Can be a string or a list of strings separated by spaces in the format of `"key1=value1" "key2=value2"`. See the VSPipe [documentation](https://www.vapoursynth.com/doc/output.html#options) for more information.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --vspipe-args "message=fluffy kittens" "head=empty"` - Passes `message=fluffy kittens` and `head=empty` to vspipe with generated loadscript.vpy
+* `> av1an -i input.vpy -o output.mkv --vspipe-args "blur=10"` - Passes `blur=10` to vspipe with input.vpy
+
+## Help `-h`, `--help`
+
+Print help information.
+
+## Version `-V`, `--version`
+
+Print version information.

--- a/site/src/Cli/general.md
+++ b/site/src/Cli/general.md
@@ -16,6 +16,7 @@ Name | Flag | Type | Default
 [Overwrite](#overwrite--y) | `-y` | 
 [Never Overwrite](#never-overwrite--n) | `-n` | 
 [Max Tries](#max-tries---max-tries) | `--max-tries` | Integer | 3
+[Workers](#workers---workers) | `--workers` | Integer | `0` (Automatic)
 [Thread Affinity](#thread-affinity---set-thread-affinity) | `--set-thread-affinity` | Integer | 
 [Scaler](#scaler---scaler) | `--scaler` | `SCALER` | `bicubic`
 [VSPipe Arguments](#vspipe-arguments---vspipe-args) | `--vspipe-args` | String List | 

--- a/site/src/Cli/scene_detection.md
+++ b/site/src/Cli/scene_detection.md
@@ -1,68 +1,134 @@
+# Scene Detection
 
-## Scene detection
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[Scenes](#scenes--s---scenes) | `-s`, `--scenes` | Path | 
+[Scene Detection Only](#scene-detection-only---sc-only) | `--sc-only` | 
+[Split Method](#split-method---split-method) | `--split-method` | `SPLIT_METHOD` | `av-scenechange`
+[Scene Detection Method](#scene-detection-method---sc-method) | `--sc-method` | `SC_METHOD` | `standard`
+[Scene Downscale Height](#scene-downscale-height---sc-downscale-height) | `--sc-downscale-height` | Integer | 
+[Scene Pixel Format](#scene-pixel-format---sc-pix-format) | `--sc-pix-format` | `PIXEL_FORMAT` | 
+[Extra Split Frames](#extra-split-frames--x---extra-split) | `-x`, `--extra-split` | Integer | 
+[Extra Split Seconds](#extra-split-seconds---extra-split-sec) | `--extra-split-sec` | Integer | 10
+[Minimum Scene Length](#minimum-scene-length---min-scene-len) | `--min-scene-len` | Integer | 24
+[Force Keyframes](#force-keyframes---force-keyframes) | `--force-keyframes` | Integer List
 
-```
--s, --scenes <SCENES>
-		File location for scenes
+## Scenes `-s`, `--scenes`
 
-	--split-method <SPLIT_METHOD>
-		Method used to determine chunk boundaries
+File location for scenes.
 
-		"av-scenechange" uses an algorithm to analyze which frames of the video are the start
-		of new scenes, while "none" disables scene detection entirely (and only relies on
-		-x/--extra-split to add extra scenecuts).
+Scenes are stored as JSON.
 
-		[default: av-scenechange]
-		[possible values: av-scenechange, none]
+### Examples
 
-	--sc-method <SC_METHOD>
-		Scene detection algorithm to use for av-scenechange
+* `> av1an -i input.mkv -o output.mkv -s scenes.json` - Creates scenes file `./scenes.json`
+* `> av1an -i input.mkv -o output.mkv --scenes C:\Av1an\scenes\1.json` - Creates scenes file `C:\Av1an\scenes\1.json`
 
-		Standard: Most accurate, still reasonably fast. Uses a cost-based algorithm to determine
-		keyframes.
+## Scene Detection Only `--sc-only`
 
-		Fast: Very fast, but less accurate. Determines keyframes based on the raw difference
-		between pixels.
+Run the scene detection only before exiting.
 
-		[default: standard]
-		[possible values: standard, fast]
+Requires a scene file with `--scenes`.
 
-	--sc-only
-		Run the scene detection only before exiting
+## Split Method `--split-method`
 
-		Requires a scene file with --scenes.
+Method used to determine chunk boundaries.
 
-	--sc-pix-format <SC_PIX_FORMAT>
-		Perform scene detection with this pixel format
+"av-scenechange" uses an algorithm to analyze which frames of the video are the start of new scenes, while "none" disables scene detection entirely (and only relies on -x/--extra-split to add extra scenecuts).
 
-	--sc-downscale-height <SC_DOWNSCALE_HEIGHT>
-		Optional downscaling for scene detection
+### Possible Values
 
-		Specify as the desired maximum height to scale to (e.g. "720" to downscale to 720p
-		— this will leave lower resolution content untouched). Downscaling improves scene
-		detection speed but lowers accuracy, especially when scaling to very low resolutions.
+* `av-scenechange`
+* `none`
 
-		By default, no downscaling is performed.
+### Default
 
--x, --extra-split <EXTRA_SPLIT>
-		Maximum scene length, in frames
+If not specified, `av-scenechange` is used.
 
-		When a scenecut is found whose distance to the previous scenecut is greater than the
-		value specified by this option, one or more extra splits (scenecuts) are added. Set this
-		option to 0 to disable adding extra splits.
+## Scene Detection Method `--sc-method`
 
-    --extra-split-sec <EXTRA_SPLIT_SEC>
-		Maximum scene length, in seconds
+Scene detection algorithm to use for av-scenechange.
 
-        If both frames and seconds are specified, then the number of frames will take priority.
+### Possible Values
 
-		[default: 10]
+* `standard` - Most accurate, still reasonably fast. Uses a cost-based algorithm to determine keyframes.
+* `fast` - Very fast, but less accurate. Determines keyframes based on the raw difference between pixels.
 
-	--min-scene-len <MIN_SCENE_LEN>
-		Minimum number of frames for a scenecut
+### Default
 
-		[default: 24]
+If not specified, `standard` is used.
 
-    --ignore-frame-mismatch
-        Ignore any detected mismatch between scene frame count and encoder frame count
-```
+## Scene Downscale Height `--sc-downscale-height`
+
+Optional downscaling for scene detection.
+
+Specify as the desired maximum height to scale to (e.g. `720` to downscale to 720p — this will leave lower resolution content untouched). Downscaling improves scene detection speed but lowers accuracy, especially when scaling to very low resolutions.
+
+By default, no downscaling is performed.
+
+## Scene Pixel Format `--sc-pix-format`
+
+Perform scene detection with this pixel format.
+
+### Possible Values
+
+Any valid pixel format name. See [FFmpeg](https://www.ffmpeg.org/doxygen/0.11/pixfmt_8h.html#60883d4958a60b91661e97027a85072a) for a full list.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --sc-pix-format yuv420p` - Use YUV420P for scene detection
+* `> av1an -i input.mkv -o output.mkv --sc-pix-format yuv444p` - Use YUV444P for scene detection
+
+## Extra Split Frames `-x`, `--extra-split`
+
+Maximum scene length, in frames.
+
+When a scenecut is found whose distance to the previous scenecut is greater than the value specified by this option, one or more extra splits (scenecuts) are added. Set this option to `0` to disable adding extra splits.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv -x 100` - Adds an extra split every 100 frames
+* `> av1an -i input.mkv -o output.mkv --extra-split 240` - Adds an extra split every 240 frames
+* `> av1an -i input.mkv -o output.mkv --extra-split 0` - Disables adding extra splits
+
+## Extra Split Seconds `--extra-split-sec`
+
+Maximum scene length, in seconds.
+
+If both frames and seconds are specified, then the number of frames will take priority.
+
+### Default
+
+If not specified, `10` is used.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --extra-split-sec 10` - Adds an extra split every 10 seconds
+* `> av1an -i input.mkv -o output.mkv --extra-split-sec 5` - Adds an extra split every 5 seconds
+* `> av1an -i input.mkv -o output.mkv --extra-split-sec 15 --extra-split 50` - Adds an extra split every 50 frames, ignoring `--extra-split-sec 15`
+
+## Minimum Scene Length `--min-scene-len`
+
+Minimum number of frames for a scenecut.
+
+If a scene contains fewer frames than this value, it will not be cut.
+
+### Default
+
+If not specified, `24` is used.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --min-scene-len 60` - Adds an extra split every 60 frames
+
+## Force Keyframes `--force-keyframes`
+
+List of frames to force as keyframes.
+
+### Possible Values
+
+A comma-separated list of frame numbers as positive integers.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --force-keyframes 82,346,622` - Force frames 82, 346, and 622 as keyframes

--- a/site/src/Cli/target_quality.md
+++ b/site/src/Cli/target_quality.md
@@ -1,45 +1,86 @@
 # Target Quality
 
-```
-	--target-quality <TARGET_QUALITY>
-		Target a VMAF score for encoding (disabled by default)
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[Target Quality](#target-quality---target-quality) | `--target-quality` | Float | 
+[Probes](#probes---probes) | `--probes` | Integer | `4`
+[Probing Rate](#probing-rate---probing-rate) | `--probing-rate` | Integer | `1`
+[Probe Slow](#probe-slow---probe-slow) | `--probe-slow` || 
+[Minimum Quantizer](#minimum-quantizer---min-q) | `--min-q` | Integer | Based on Encoder
+[Maximum Quantizer](#maximum-quantizer---max-q) | `--max-q` | Integer | Based on Encoder
 
-		For each chunk, target quality uses an algorithm to find the quantizer/crf needed to
-		achieve a certain VMAF score. Target quality mode is much slower than normal encoding,
-		but can improve the consistency of quality in some cases.
 
-		The VMAF score range is 0-100 (where 0 is the worst quality, and 100 is the best).
-		Floating-point values are allowed.
+## Target Quality `--target-quality`
 
-	--probes <PROBES>
-		Maximum number of probes allowed for target quality
+Target a [VMAF](https://github.com/Netflix/vmaf) score for encoding.
 
-		[default: 4]
+For each chunk, Target Quality searches for the quantizer/crf needed to achieve a certain VMAF score. Target Quality mode is much slower than normal encoding, but can improve the consistency of quality in some cases.
 
-	--probing-rate <PROBING_RATE>
-		Framerate for probes, 1 - original
+The VMAF score range is `0`-`100` where `0` is the worst quality and `100` is the best.
 
-		[default: 1]
+### Possible Values
 
-	--probe-slow
-		Use encoding settings for probes specified by --video-params rather than faster, less
-		accurate settings
+Any float value between `0` and `100`.
 
-		Note that this always performs encoding in one-pass mode, regardless of --passes.
+### Examples
 
-	--min-q <MIN_Q>
-		Lower bound for target quality Q-search early exit
+* `> av1an -i input.mkv -o output.mkv --target-quality 80` - Target a VMAF score of 80
+* `> av1an -i input.mkv -o output.mkv --target-quality 90.5` - Target a VMAF score of 90.5
 
-		If min_q is tested and the probe's VMAF score is lower than target_quality, the Q-search
-		early exits and min_q is used for the chunk.
+## Probes `--probes`
 
-		If not specified, the default value is used (chosen per encoder).
+Maximum number of probes allowed for Target Quality.
 
-	--max-q <MAX_Q>
-		Upper bound for target quality Q-search early exit
+### Possible Values
 
-		If max_q is tested and the probe's VMAF score is higher than target_quality, the Q-
-		search early exits and max_q is used for the chunk.
+Can be any positive integer.
 
-		If not specified, the default value is used (chosen per encoder).
-```
+### Default
+
+If not specified, `4` is used.
+
+## Probing Rate `--probing-rate`
+
+Framerate for probes.
+
+### Possible Values
+
+Can be any integer from `1` to `4`.
+
+### Default
+
+If not specified, `1` is used.
+
+## Probe Slow `--probe-slow`
+
+Use encoding settings for probes specified by `--video-params` rather than faster, less accurate settings.
+
+Note that this always performs encoding in one-pass mode, regardless of `--passes`.
+
+## Minimum Quantizer `--min-q`
+
+Lower bound for Target Quality Quantizer-search early exit.
+
+If the minimum quantizer is tested and the probe's VMAF score is lower than the Target Quality (`--target-quality`), the Quantizer-search exits early and the minimum quantizer is used for the chunk.
+
+### Possible Values
+
+Depends on the encoder.
+
+### Default
+
+If not specified, the default value is used (chosen per encoder).
+
+## Maximum Quantizer `--max-q`
+
+Upper bound for Target Quality Quantizer-search early exit.
+
+If the maximum quantizer is tested and the probe's VMAF score is higher than the Target Quality (`--target-quality`), the Quantizer-search exits early and the maximum quantizer is used for the chunk.
+
+### Possible Values
+
+Depends on the encoder.
+
+### Default
+
+If not specified, the default value is used (chosen per encoder).

--- a/site/src/Cli/vmaf.md
+++ b/site/src/Cli/vmaf.md
@@ -1,30 +1,46 @@
-
 # VMAF
 
-```
-	--vmaf
-		Plot an SVG of the VMAF for the encode
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[VMAF](#vmaf---vmaf) | `--vmaf` || 
+[VMAF Path](#vmaf-path---vmaf-path) | `--vmaf-path` | String | 
+[VMAF Resolution](#vmaf-resolution---vmaf-res) | `--vmaf-res` | String | `1920x1080`
+[VMAF Threads](#vmaf-threads---vmaf-threads) | `--vmaf-threads` | Integer | 
+[VMAF Filter](#vmaf-filter---vmaf-filter) | `--vmaf-filter` | String | 
 
-		This option is independent of --target-quality, i.e. it can be used with or without it.
-		The SVG plot is created in the same directory as the output file.
 
-	--vmaf-path <VMAF_PATH>
-		Path to VMAF model (used by --vmaf and --target-quality)
+## VMAF `--vmaf`
 
-		If not specified, ffmpeg's default is used.
+Plot an SVG of the [VMAF](https://github.com/Netflix/vmaf) for the encode.
 
-	--vmaf-res <VMAF_RES>
-		Resolution used for VMAF calculation
+This option is independent of [Target Quality](./target_quality.md) (`--target-quality`), i.e. it can be used with or without it. The SVG plot is created in the same directory as the [Output](./general.md#output--o) file.
 
-        If set to inputres, the output video will be scaled to the resolution of the input video.
+## VMAF Path `--vmaf-path`
 
-		[default: 1920x1080]
+Path to VMAF model.
 
-	--vmaf-threads <VMAF_THREADS>
-		Number of threads to use for target quality VMAF calculation
+This option is also used by [Target Quality](./target_quality.md) (`--target-quality`).
 
-	--vmaf-filter <VMAF_FILTER>
-		Filter applied to source at VMAF calcualation
+### Default
 
-		This option should be specified if the source is cropped, for example.
-```
+If not specified, FFmpeg's default is used.
+
+## VMAF Resolution `--vmaf-res`
+
+Resolution used for VMAF calculation.
+
+If set to the input resolution, the output video will be scaled to the resolution of the input video.
+
+### Default
+
+If not specified, `1920x1080` is used.
+
+## VMAF Threads `--vmaf-threads`
+
+Number of threads to use for [Target Quality](./target_quality.md) (`--target-quality`) VMAF calculation.
+
+## VMAF Filter `--vmaf-filter`
+
+Filter applied to source at VMAF calcualation.
+
+This option should be specified if the source is cropped, for example.

--- a/site/src/av1an.md
+++ b/site/src/av1an.md
@@ -5,3 +5,89 @@ It can increase your encoding speed and improve cpu utilization by running multi
 Target quality, VMAF plotting, and more, available to take advantage for video encoding.
 
 For help with av1an, please reach out to us on Discord or file a GitHub issue
+
+## Parameters
+
+For more details, see documentation for each parameter or run `av1an --help`.
+
+### [General](./Cli/general.md)
+
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[Input](./Cli/general.md#input--i) | `-i` | Path
+[Output](./Cli/general.md#output--o) | `-o` | Path
+[Temporary](./Cli/general.md#temporary---temp) | `--temp` | Path | Input file name hash
+[Quiet](./Cli/general.md#quiet--q---quiet) | `-q` | 
+[Verbose](./Cli/general.md#verbose---verbose) | `--verbose` | 
+[Log File](./Cli/general.md#log-file--l---log-file) | `-l`, `--log-file` | Path | `./logs/av1an.log`
+[Log Level](./Cli/general.md#log-level---log-level) | `--log-level` | `LOG_LEVEL` | `debug`
+[Resume](./Cli/general.md#resume---resume) | `--resume` | 
+[Keep](./Cli/general.md#keep--k---keep) | `-k`, `--keep` | 
+[Force](./Cli/general.md#force---force) | `--force` | 
+[No Defaults](./Cli/general.md#no-defaults---no-defaults) | `--no-defaults` | 
+[Overwrite](./Cli/general.md#overwrite--y) | `-y` | 
+[Never Overwrite](./Cli/general.md#never-overwrite--n) | `-n` | 
+[Max Tries](./Cli/general.md#max-tries---max-tries) | `--max-tries` | Integer | 3
+[Workers](./Cli/general.md#workers---workers) | `--workers` | Integer | `0` (Automatic)
+[Thread Affinity](./Cli/general.md#thread-affinity---set-thread-affinity) | `--set-thread-affinity` | Integer | 
+[Scaler](./Cli/general.md#scaler---scaler) | `--scaler` | `SCALER` | `bicubic`
+[VSPipe Arguments](./Cli/general.md#vspipe-arguments---vspipe-args) | `--vspipe-args` | String List | 
+[Help](./Cli/general.md#help--h---help) | `-h`, `--help` | 
+[Version](./Cli/general.md#version--v---version) | `-V`, `--version` | 
+
+### [Scene Detection](./Cli/scene_detection.md)
+
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[Scenes](./Cli/scene_detection.md#scenes--s---scenes) | `-s`, `--scenes` | Path | 
+[Scene Detection Only](./Cli/scene_detection.md#scene-detection-only---sc-only) | `--sc-only` | 
+[Split Method](./Cli/scene_detection.md#split-method---split-method) | `--split-method` | `SPLIT_METHOD` | `av-scenechange`
+[Scene Detection Method](./Cli/scene_detection.md#scene-detection-method---sc-method) | `--sc-method` | `SC_METHOD` | `standard`
+[Scene Downscale Height](./Cli/scene_detection.md#scene-downscale-height---sc-downscale-height) | `--sc-downscale-height` | Integer | 
+[Scene Pixel Format](./Cli/scene_detection.md#scene-pixel-format---sc-pix-format) | `--sc-pix-format` | `PIXEL_FORMAT` | 
+[Extra Split Frames](./Cli/scene_detection.md#extra-split-frames--x---extra-split) | `-x`, `--extra-split` | Integer | 
+[Extra Split Seconds](./Cli/scene_detection.md#extra-split-seconds---extra-split-sec) | `--extra-split-sec` | Integer | 10
+[Minimum Scene Length](./Cli/scene_detection.md#minimum-scene-length---min-scene-len) | `--min-scene-len` | Integer | 24
+[Force Keyframes](./Cli/scene_detection.md#force-keyframes---force-keyframes) | `--force-keyframes` | Integer List
+
+### [Encoding](./Cli/encoding.md)
+
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[Encoder](./Cli/encoding.md#encoder--e---encoder) | `-e`, `--encoder` | `ENCODER` | `aom`
+[Video Parameters](./Cli/encoding.md#video-parameters--v---video-params) | `-v`, `--video-params` | String List | Based on Encoder
+[Passes](./Cli/encoding.md#passes--p---passes) | `-p`, `--passes` | Integer | 1
+[Tile Auto](./Cli/encoding.md#tile-auto---tile-auto) | `--tile-auto` || 
+[FFmpeg Parameters](./Cli/encoding.md#ffmpeg-filter-arguments--f---ffmpeg) | `-f`, `--ffmpeg` | String |
+[Audio Parameters](./Cli/encoding.md#audio-parameters--a---audio-params) | `-a`, `--audio-params` | String |
+[Ignore Frame Mismatch](./Cli/encoding.md#ignore-frame-mismatch---ignore-frame-mismatch) | `--ignore-frame-mismatch` | 
+[Chunk Method](./Cli/encoding.md#chunk-method--m---chunk-method) | `-m`, `--chunk-method` | `CHUNK_METHOD` | `lsmash`
+[Chunk Order](./Cli/encoding.md#chunk-order---chunk-order) | `--chunk-order` | `CHUNK_ORDER` | `long-to-short`
+[Photon Noise](./Cli/encoding.md#photon-noise---photon-noise) | `--photon-noise` | Integer |
+[Chroma Noise](./Cli/encoding.md#chroma-noise---chroma-noise) | `--chroma-noise` || 
+[Photon Noise Width](./Cli/encoding.md#photon-noise-width---photon-noise-width) |`--photon-noise-width` | Integer |
+[Photon Noise Height](./Cli/encoding.md#photon-noise-height---photon-noise-height) | `--photon-noise-height` | Integer |
+[Concatenation Method](./Cli/encoding.md#concatenation-method--c---concat) | `-c`, `--concat` | `CONCAT` | `ffmpeg`
+[Pixel Format](./Cli/encoding.md#pixel-format---pix-format) | `--pix-format` | `PIX_FORMAT` | `yuv420p10le`
+[Zones](./Cli/encoding.md#zones---zones) | `-z`, `--zones` | Path | 
+
+### [VMAF](./Cli/vmaf.md)
+
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[VMAF](./Cli/vmaf.md#vmaf---vmaf) | `--vmaf` || 
+[VMAF Path](./Cli/vmaf.md#vmaf-path---vmaf-path) | `--vmaf-path` | String | 
+[VMAF Resolution](./Cli/vmaf.md#vmaf-resolution---vmaf-res) | `--vmaf-res` | String | `1920x1080`
+[VMAF Threads](./Cli/vmaf.md#vmaf-threads---vmaf-threads) | `--vmaf-threads` | Integer | 
+[VMAF Filter](./Cli/vmaf.md#vmaf-filter---vmaf-filter) | `--vmaf-filter` | String | 
+
+### [Target Quality](./Cli/target_quality.md)
+
+Name | Flag | Type | Default
+--- | --- | --- | ---
+[Target Quality](./Cli/target_quality.md#target-quality---target-quality) | `--target-quality` | Float | 
+[Probes](./Cli/target_quality.md#probes---probes) | `--probes` | Integer | `4`
+[Probing Rate](./Cli/target_quality.md#probing-rate---probing-rate) | `--probing-rate` | Integer | `1`
+[Probe Slow](./Cli/target_quality.md#probe-slow---probe-slow) | `--probe-slow` || 
+[Minimum Quantizer](./Cli/target_quality.md#minimum-quantizer---min-q) | `--min-q` | Integer | Based on Encoder
+[Maximum Quantizer](./Cli/target_quality.md#maximum-quantizer---max-q) | `--max-q` | Integer | Based on Encoder


### PR DESCRIPTION
This is a continuation of #962 for the remaining CLI documents. There are also fixes to the main readme.md - mainly updates to links and some grammar.

Next steps:

* Update inaccurate information on some of the chunking methods - docs suggest VS methods don't generate temporary files but they do (mainly indexing files)
* Update `av1an/src/main.rs` parameters to match the new documentation
  * Reorder for consistency
  * Update grammar (ex. "ffmpeg" must be "FFmpeg" to comply with license [checklist item 15](https://www.ffmpeg.org/legal.html#:~:text=Do%20not%20misspell%20FFmpeg%20(two%20capitals%20F%20and%20lowercase%20%22mpeg%22).))
* Make new pages to clean up main readme.md:
  * Installation for more details on installing - doing this in readme would be too verbose
  * Usage + examples - would be nice to have animated webp showcase of the TUI (both on readme and docs)
* Developer documentation - Each file/configuration generated or used by Av1an should be documented: Why do we need this, what does it do, etc. and most importantly *how should it be implemented*
  * Loadscript.vpy
  * Scenes.json
  * Chunks.json
  * Done.json

I would also like to further improve information on VMAF and Target Quality. I invite anyone more familiar than I am to fill in missing info. I don't use these features so I was a bit lazy on some of the sections like `Target Quality -> Minimum Quantizer`. I would have to further dig into the code to get exact values but I'm also more interested in reimplementing it differently with newer features and procedures.

Thanks,
\- Boats M.