### PR TITLE
Add CTRL+C SIGINT handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "cfg-if",
  "crossbeam-channel",
  "crossbeam-utils",
+ "ctrlc",
  "dashmap",
  "ffmpeg-the-third",
  "indicatif",
@@ -423,6 +424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clang"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +542,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "ctrlc"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "darling"
@@ -1174,6 +1191,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -58,6 +58,7 @@ tracing = "0.1"
 tokio = { version = "1.43", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 regex = "1.11.1"
+ctrlc = "3.4.6"
 
 # TODO: https://github.com/elast0ny/affinity/issues/2
 # update this when macos support is implemented


### PR DESCRIPTION
Sending `SIGINT` (pressing CTRL+C) while encoding currently terminates the chunk encoder, causing Av1an to retry the chunk and requiring the user to send multiple signals to terminate. This PR aims to bring that down to 1 command. There are also 2 open issues requesting that sending `SIGINT` should let the chunk(s) finish but not start any more until all are completed and Av1an exits early with no progress lost. That is the secondary goal for this PR but I'm not sure how to implement that yet.

This is a work in progress and there needs to be better logging for these new scenarios. It also needs to be applied in more parts of the code, such as in the Target Quality search before chunk encoding starts. I also need to test several different configurations like multiple input files, multiple workers, Linux, etc.

Thanks,
\- Boats M.