### PR TITLE
Fix logging

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -164,7 +164,7 @@ impl Broker<'_> {
     }
   }
 
-  #[tracing::instrument(skip(self))]
+  #[tracing::instrument(skip(self, chunk), fields(chunk_index = format!("{:>05}", chunk.index)))]
   fn encode_chunk(&self, chunk: &mut Chunk, worker_id: usize) -> Result<(), Box<EncoderCrash>> {
     let st_time = Instant::now();
 

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -270,9 +270,8 @@ impl Av1anContext {
       }
       self.args.workers = cmp::min(self.args.workers, chunk_queue.len());
 
-      if std::io::stderr().is_terminal() {
-        eprintln!(
-          "{}{} {} {}{} {} {}{} {} {}{} {}\n{}: {}",
+      info!(
+        "\n{}{} {} {}{} {} {}{} {} {}{} {}\n{}: {}",
           Color::Green.bold().paint("Q"),
           Color::Green.paint("ueue"),
           Color::Green.bold().paint(format!("{}", chunk_queue.len())),
@@ -290,16 +289,6 @@ impl Av1anContext {
             .dimmed()
             .paint(self.args.video_params.join(" "))
         );
-      } else {
-        eprintln!(
-          "Queue {} Workers {} Encoder {} Passes {}\nParams: {}",
-          chunk_queue.len(),
-          self.args.workers,
-          self.args.encoder,
-          self.args.passes,
-          self.args.video_params.join(" ")
-        );
-      }
 
       if self.args.verbosity == Verbosity::Normal {
         init_progress_bar(self.frames as u64, initial_frames as u64);

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::{IsTerminal, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command, Stdio};
 use std::sync::atomic::{self, AtomicBool, AtomicUsize};
@@ -141,7 +141,7 @@ impl Av1anContext {
     Ok(())
   }
 
-  #[tracing::instrument]
+  #[tracing::instrument(skip(self))]
   pub fn encode_file(&mut self) -> anyhow::Result<()> {
     let initial_frames = get_done()
       .done
@@ -272,23 +272,23 @@ impl Av1anContext {
 
       info!(
         "\n{}{} {} {}{} {} {}{} {} {}{} {}\n{}: {}",
-          Color::Green.bold().paint("Q"),
-          Color::Green.paint("ueue"),
-          Color::Green.bold().paint(format!("{}", chunk_queue.len())),
-          Color::Blue.bold().paint("W"),
-          Color::Blue.paint("orkers"),
-          Color::Blue.bold().paint(format!("{}", self.args.workers)),
-          Color::Purple.bold().paint("E"),
-          Color::Purple.paint("ncoder"),
-          Color::Purple.bold().paint(format!("{}", self.args.encoder)),
-          Color::Purple.bold().paint("P"),
-          Color::Purple.paint("asses"),
-          Color::Purple.bold().paint(format!("{}", self.args.passes)),
-          Style::default().bold().paint("Params"),
-          Style::default()
-            .dimmed()
-            .paint(self.args.video_params.join(" "))
-        );
+        Color::Green.bold().paint("Q"),
+        Color::Green.paint("ueue"),
+        Color::Green.bold().paint(format!("{}", chunk_queue.len())),
+        Color::Blue.bold().paint("W"),
+        Color::Blue.paint("orkers"),
+        Color::Blue.bold().paint(format!("{}", self.args.workers)),
+        Color::Purple.bold().paint("E"),
+        Color::Purple.paint("ncoder"),
+        Color::Purple.bold().paint(format!("{}", self.args.encoder)),
+        Color::Purple.bold().paint("P"),
+        Color::Purple.paint("asses"),
+        Color::Purple.bold().paint(format!("{}", self.args.passes)),
+        Style::default().bold().paint("Params"),
+        Style::default()
+          .dimmed()
+          .paint(self.args.video_params.join(" "))
+      );
 
       if self.args.verbosity == Verbosity::Normal {
         init_progress_bar(self.frames as u64, initial_frames as u64);

--- a/av1an-core/src/logging.rs
+++ b/av1an-core/src/logging.rs
@@ -123,21 +123,6 @@ pub fn init_logging(console_level: LevelFilter, log_path: PathBuf, file_level: L
 
   // Create our subscriber with correctly ordered layers
   let subscriber = tracing_subscriber::registry()
-    // Console output layer
-    .with(
-      fmt::Layer::new()
-        // First configure all formatting
-        .with_ansi(std::io::stderr().is_terminal())
-        .with_target(true)
-        .with_thread_ids(false)
-        .with_file(false)
-        .with_line_number(false)
-        .with_level(true)
-        // Set the writer
-        .with_writer(std::io::stdout)
-        // Apply the filter last
-        .with_filter(console_filter),
-    )
     // File output layer
     .with(
       fmt::Layer::new()
@@ -153,6 +138,21 @@ pub fn init_logging(console_level: LevelFilter, log_path: PathBuf, file_level: L
         .with_writer(non_blocking)
         // Apply the filter last
         .with_filter(file_filter),
+    )
+    // Console output layer
+    .with(
+      fmt::Layer::new()
+        // First configure all formatting
+        .with_ansi(std::io::stderr().is_terminal())
+        .with_target(true)
+        .with_thread_ids(false)
+        .with_file(false)
+        .with_line_number(false)
+        .with_level(true)
+        // Set the writer
+        .with_writer(std::io::stdout)
+        // Apply the filter last
+        .with_filter(console_filter),
     );
 
   // Set as global default

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -9,6 +9,7 @@ use std::thread::available_parallelism;
 use ffmpeg::format::Pixel;
 use serde::{Deserialize, Serialize};
 use splines::{Interpolation, Key, Spline};
+use tracing::{debug, error};
 
 use crate::broker::EncoderCrash;
 use crate::chunk::Chunk;


### PR DESCRIPTION
A collection of fixes for logging:

* Large `Chunk` object will no longer be printed on every log during encoding - logs are no longer overly verbose or redundant (first log prints the `Av1anContext`)
* Add missing `use tracing` for Target Quality - Target Quality debug logs now work as expected
* Update old log to tracing during encoding - addresses issue where `--quiet` still logged it to terminal
* Fix log file objects have ANSI characters that cannot be displayed in files - log files objects are now more readable
* Target Quality VMAF target value is printed to the progress bar during target quality search for the chunk - addresses #934 but can be further improved to address a different issue

```
av1an.exe -i a.mkv --temp temporary --keep -w 2 -e svt-av1 --pix-format yuv420p -s a.json --sc-method fast --sc-downscale-height 720 -m ffms2 -y --verbose -l after.log --target-quality 95
2025-04-27T15:06:27.794023Z  INFO av1an_core::logging: Logging system initialized
2025-04-27T15:06:27.869203Z  INFO encode_file{self=Av1anContext { frames: 0, vs_script: None, vs_scd_script: None, args: EncodeArgs { input: Video { path: "a.mkv" }, temp: "temporary", output_file: "a_svt-av1.mkv", chunk_method: FFMS2, chunk_order: LongestFirst, scaler: "bicubic+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact", scenes: Some("a.json"), split_method: AvScenechange, sc_pix_format: None, sc_method: Fast, sc_only: false, sc_downscale_height: Some(720), extra_splits_len: Some(299), min_scene_len: 24, force_keyframes: [], ignore_frame_mismatch: false, max_tries: 3, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], tiles: (1, 1), encoder: svt_av1, workers: 2, set_thread_affinity: None, photon_noise: None, photon_noise_size: (None, None), chroma_noise: false, zones: None, ffmpeg_filter_args: [], audio_params: ["-c:a", "copy"], input_pix_format: FFmpeg { format: YUV420P }, output_pix_format: PixelFormat { format: YUV420P, bit_depth: 8 }, verbosity: Verbose, log_file: "before.log", log_level: LevelFilter::DEBUG, resume: false, keep: true, force: false, no_defaults: false, tile_auto: false, concat: FFmpeg, target_quality: Some(TargetQuality { vmaf_res: "1920x1080", vmaf_scaler: "bicubic", vmaf_filter: None, vmaf_threads: 8, model: None, probing_rate: 1, probes: 4, target: 95.0, min_q: 15, max_q: 50, encoder: svt_av1, pix_format: YUV420P, temp: "temporary", workers: 2, video_params: [], vspipe_args: [], probe_slow: false }), vmaf: false, vmaf_path: None, vmaf_res: "1920x1080", vmaf_threads: None, vmaf_filter: None } }}: av1an_core::context: Input: 720x480 @ 29.970 fps, YUV420P, SDR
Queue 6 Workers 2 Encoder svt-av1 Passes 1
Params: --preset 4 --keyint 0 --scd 0 --rc 0 --crf 25
[Chunk 0] Encoding frame   36 1791.47 kbps 12.78 fps
[Chunk 1] Encoding frame   48 2070.67 kbps 14.79 fps
00:00:38 ▐█████████████████████████████████████████████████▌ 100% 363/363 (9.39 fps, eta 0s, 2022.6 Kbps, est. 3.27 MiB)
```

<details>
<summary>
after.log
</summary>

```
2025-04-27T15:06:27.794482Z  INFO main ThreadId(01) av1an_core::logging: av1an-core\src\logging.rs:163: Logging system initialized
2025-04-27T15:06:27.794526Z DEBUG main ThreadId(01) av1an_core::logging: av1an-core\src\logging.rs:164: Module-specific logging enabled
2025-04-27T15:06:27.864000Z DEBUG main ThreadId(01) new{[3margs[0m[2m=[0mEncodeArgs { input: Video { path: "a.mkv" }, temp: "temporary", output_file: "a_svt-av1.mkv", chunk_method: FFMS2, chunk_order: LongestFirst, scaler: "bicubic+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact", scenes: Some("a.json"), split_method: AvScenechange, sc_pix_format: None, sc_method: Fast, sc_only: false, sc_downscale_height: Some(720), extra_splits_len: Some(299), min_scene_len: 24, force_keyframes: [], ignore_frame_mismatch: false, max_tries: 3, passes: 1, video_params: [], tiles: (1, 1), encoder: svt_av1, workers: 2, set_thread_affinity: None, photon_noise: None, photon_noise_size: (None, None), chroma_noise: false, zones: None, ffmpeg_filter_args: [], audio_params: ["-c:a", "copy"], input_pix_format: FFmpeg { format: YUV420P }, output_pix_format: PixelFormat { format: YUV420P, bit_depth: 8 }, verbosity: Verbose, log_file: "before.log", log_level: LevelFilter::DEBUG, resume: false, keep: true, force: false, no_defaults: false, tile_auto: false, concat: FFmpeg, target_quality: Some(TargetQuality { vmaf_res: "1920x1080", vmaf_scaler: "bicubic", vmaf_filter: None, vmaf_threads: 8, model: None, probing_rate: 1, probes: 4, target: 95.0, min_q: 15, max_q: 50, encoder: svt_av1, pix_format: YUV420P, temp: "temporary", workers: 2, video_params: [], vspipe_args: [], probe_slow: false }), vmaf: false, vmaf_path: None, vmaf_res: "1920x1080", vmaf_threads: None, vmaf_filter: None }}:initialize{[3mself[0m[2m=[0mAv1anContext { frames: 0, vs_script: None, vs_scd_script: None, args: EncodeArgs { input: Video { path: "a.mkv" }, temp: "temporary", output_file: "a_svt-av1.mkv", chunk_method: FFMS2, chunk_order: LongestFirst, scaler: "bicubic+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact", scenes: Some("a.json"), split_method: AvScenechange, sc_pix_format: None, sc_method: Fast, sc_only: false, sc_downscale_height: Some(720), extra_splits_len: Some(299), min_scene_len: 24, force_keyframes: [], ignore_frame_mismatch: false, max_tries: 3, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], tiles: (1, 1), encoder: svt_av1, workers: 2, set_thread_affinity: None, photon_noise: None, photon_noise_size: (None, None), chroma_noise: false, zones: None, ffmpeg_filter_args: [], audio_params: ["-c:a", "copy"], input_pix_format: FFmpeg { format: YUV420P }, output_pix_format: PixelFormat { format: YUV420P, bit_depth: 8 }, verbosity: Verbose, log_file: "before.log", log_level: LevelFilter::DEBUG, resume: false, keep: true, force: false, no_defaults: false, tile_auto: false, concat: FFmpeg, target_quality: Some(TargetQuality { vmaf_res: "1920x1080", vmaf_scaler: "bicubic", vmaf_filter: None, vmaf_threads: 8, model: None, probing_rate: 1, probes: 4, target: 95.0, min_q: 15, max_q: 50, encoder: svt_av1, pix_format: YUV420P, temp: "temporary", workers: 2, video_params: [], vspipe_args: [], probe_slow: false }), vmaf: false, vmaf_path: None, vmaf_res: "1920x1080", vmaf_threads: None, vmaf_filter: None } }}: av1an_core::context: av1an-core\src\context.rs:82: temporary directory: temporary
2025-04-27T15:06:27.869670Z  INFO main ThreadId(01) encode_file{[3mself[0m[2m=[0mAv1anContext { frames: 0, vs_script: None, vs_scd_script: None, args: EncodeArgs { input: Video { path: "a.mkv" }, temp: "temporary", output_file: "a_svt-av1.mkv", chunk_method: FFMS2, chunk_order: LongestFirst, scaler: "bicubic+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact", scenes: Some("a.json"), split_method: AvScenechange, sc_pix_format: None, sc_method: Fast, sc_only: false, sc_downscale_height: Some(720), extra_splits_len: Some(299), min_scene_len: 24, force_keyframes: [], ignore_frame_mismatch: false, max_tries: 3, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], tiles: (1, 1), encoder: svt_av1, workers: 2, set_thread_affinity: None, photon_noise: None, photon_noise_size: (None, None), chroma_noise: false, zones: None, ffmpeg_filter_args: [], audio_params: ["-c:a", "copy"], input_pix_format: FFmpeg { format: YUV420P }, output_pix_format: PixelFormat { format: YUV420P, bit_depth: 8 }, verbosity: Verbose, log_file: "before.log", log_level: LevelFilter::DEBUG, resume: false, keep: true, force: false, no_defaults: false, tile_auto: false, concat: FFmpeg, target_quality: Some(TargetQuality { vmaf_res: "1920x1080", vmaf_scaler: "bicubic", vmaf_filter: None, vmaf_threads: 8, model: None, probing_rate: 1, probes: 4, target: 95.0, min_q: 15, max_q: 50, encoder: svt_av1, pix_format: YUV420P, temp: "temporary", workers: 2, video_params: [], vspipe_args: [], probe_slow: false }), vmaf: false, vmaf_path: None, vmaf_res: "1920x1080", vmaf_threads: None, vmaf_filter: None } }}: av1an_core::context: av1an-core\src\context.rs:199: Input: 720x480 @ 29.970 fps, YUV420P, SDR
2025-04-27T15:06:36.492995Z DEBUG ThreadId(08) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 3, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "168", "-e", "242"], output_ext: "ivf", start_frame: 168, end_frame: 243, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m1}: av1an_core::broker: av1an-core\src\broker.rs:176:  started chunk 00003: 75 frames
2025-04-27T15:06:39.115693Z DEBUG ThreadId(07) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 2, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "84", "-e", "167"], output_ext: "ivf", start_frame: 84, end_frame: 168, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m0}: av1an_core::broker: av1an-core\src\broker.rs:176:  started chunk 00002: 84 frames
2025-04-27T15:06:41.217649Z DEBUG ThreadId(08) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 3, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "168", "-e", "242"], output_ext: "ivf", start_frame: 168, end_frame: 243, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m1}: av1an_core::broker: av1an-core\src\broker.rs:236: finished chunk 00003: 75 frames, 5.72 fps, took 13.11s
2025-04-27T15:06:45.330278Z DEBUG ThreadId(07) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 2, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "84", "-e", "167"], output_ext: "ivf", start_frame: 84, end_frame: 168, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m0}: av1an_core::broker: av1an-core\src\broker.rs:236: finished chunk 00002: 84 frames, 4.88 fps, took 17.22s
2025-04-27T15:06:49.978242Z DEBUG ThreadId(08) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 4, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "243", "-e", "302"], output_ext: "ivf", start_frame: 243, end_frame: 303, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m1}: av1an_core::broker: av1an-core\src\broker.rs:176:  started chunk 00004: 60 frames
2025-04-27T15:06:52.996449Z DEBUG ThreadId(07) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 5, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "303", "-e", "362"], output_ext: "ivf", start_frame: 303, end_frame: 363, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m0}: av1an_core::broker: av1an-core\src\broker.rs:176:  started chunk 00005: 60 frames
2025-04-27T15:06:55.923448Z DEBUG ThreadId(08) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 4, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "243", "-e", "302"], output_ext: "ivf", start_frame: 243, end_frame: 303, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m1}: av1an_core::broker: av1an-core\src\broker.rs:236: finished chunk 00004: 60 frames, 4.10 fps, took 14.63s
2025-04-27T15:06:57.024422Z DEBUG ThreadId(07) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 5, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "303", "-e", "362"], output_ext: "ivf", start_frame: 303, end_frame: 363, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m0}: av1an_core::broker: av1an-core\src\broker.rs:236: finished chunk 00005: 60 frames, 5.13 fps, took 11.69s
2025-04-27T15:07:02.353035Z DEBUG ThreadId(08) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 1, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "36", "-e", "83"], output_ext: "ivf", start_frame: 36, end_frame: 84, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m1}: av1an_core::broker: av1an-core\src\broker.rs:176:  started chunk 00001: 48 frames
2025-04-27T15:07:03.205006Z DEBUG ThreadId(07) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 0, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "0", "-e", "35"], output_ext: "ivf", start_frame: 0, end_frame: 36, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m0}: av1an_core::broker: av1an-core\src\broker.rs:176:  started chunk 00000: 36 frames
2025-04-27T15:07:06.674052Z DEBUG ThreadId(08) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 1, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "36", "-e", "83"], output_ext: "ivf", start_frame: 36, end_frame: 84, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m1}: av1an_core::broker: av1an-core\src\broker.rs:236: finished chunk 00001: 48 frames, 4.47 fps, took 10.75s
2025-04-27T15:07:06.766164Z DEBUG ThreadId(07) encode_chunk{[3mchunk[0m[2m=[0mChunk { temp: "temporary", index: 0, input: VapourSynth { path: "temporary\\split\\loadscript.vpy", vspipe_args: [] }, source_cmd: ["vspipe", "temporary\\split\\loadscript.vpy", "-c", "y4m", "-", "-s", "0", "-e", "35"], output_ext: "ivf", start_frame: 0, end_frame: 36, frame_rate: 29.97002997002997, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], encoder: svt_av1, noise_size: (None, None), tq_cq: None, ignore_frame_mismatch: false } [3mworker_id[0m[2m=[0m0}: av1an_core::broker: av1an-core\src\broker.rs:236: finished chunk 00000: 36 frames, 3.70 fps, took 9.74s
2025-04-27T15:07:06.771099Z DEBUG main ThreadId(01) encode_file{[3mself[0m[2m=[0mAv1anContext { frames: 0, vs_script: None, vs_scd_script: None, args: EncodeArgs { input: Video { path: "a.mkv" }, temp: "temporary", output_file: "a_svt-av1.mkv", chunk_method: FFMS2, chunk_order: LongestFirst, scaler: "bicubic+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact", scenes: Some("a.json"), split_method: AvScenechange, sc_pix_format: None, sc_method: Fast, sc_only: false, sc_downscale_height: Some(720), extra_splits_len: Some(299), min_scene_len: 24, force_keyframes: [], ignore_frame_mismatch: false, max_tries: 3, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], tiles: (1, 1), encoder: svt_av1, workers: 2, set_thread_affinity: None, photon_noise: None, photon_noise_size: (None, None), chroma_noise: false, zones: None, ffmpeg_filter_args: [], audio_params: ["-c:a", "copy"], input_pix_format: FFmpeg { format: YUV420P }, output_pix_format: PixelFormat { format: YUV420P, bit_depth: 8 }, verbosity: Verbose, log_file: "before.log", log_level: LevelFilter::DEBUG, resume: false, keep: true, force: false, no_defaults: false, tile_auto: false, concat: FFmpeg, target_quality: Some(TargetQuality { vmaf_res: "1920x1080", vmaf_scaler: "bicubic", vmaf_filter: None, vmaf_threads: 8, model: None, probing_rate: 1, probes: 4, target: 95.0, min_q: 15, max_q: 50, encoder: svt_av1, pix_format: YUV420P, temp: "temporary", workers: 2, video_params: [], vspipe_args: [], probe_slow: false }), vmaf: false, vmaf_path: None, vmaf_res: "1920x1080", vmaf_threads: None, vmaf_filter: None } }}: av1an_core::context: av1an-core\src\context.rs:346: encoding finished, concatenating with ffmpeg
2025-04-27T15:07:06.771883Z DEBUG main ThreadId(01) encode_file{[3mself[0m[2m=[0mAv1anContext { frames: 0, vs_script: None, vs_scd_script: None, args: EncodeArgs { input: Video { path: "a.mkv" }, temp: "temporary", output_file: "a_svt-av1.mkv", chunk_method: FFMS2, chunk_order: LongestFirst, scaler: "bicubic+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact", scenes: Some("a.json"), split_method: AvScenechange, sc_pix_format: None, sc_method: Fast, sc_only: false, sc_downscale_height: Some(720), extra_splits_len: Some(299), min_scene_len: 24, force_keyframes: [], ignore_frame_mismatch: false, max_tries: 3, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], tiles: (1, 1), encoder: svt_av1, workers: 2, set_thread_affinity: None, photon_noise: None, photon_noise_size: (None, None), chroma_noise: false, zones: None, ffmpeg_filter_args: [], audio_params: ["-c:a", "copy"], input_pix_format: FFmpeg { format: YUV420P }, output_pix_format: PixelFormat { format: YUV420P, bit_depth: 8 }, verbosity: Verbose, log_file: "before.log", log_level: LevelFilter::DEBUG, resume: false, keep: true, force: false, no_defaults: false, tile_auto: false, concat: FFmpeg, target_quality: Some(TargetQuality { vmaf_res: "1920x1080", vmaf_scaler: "bicubic", vmaf_filter: None, vmaf_threads: 8, model: None, probing_rate: 1, probes: 4, target: 95.0, min_q: 15, max_q: 50, encoder: svt_av1, pix_format: YUV420P, temp: "temporary", workers: 2, video_params: [], vspipe_args: [], probe_slow: false }), vmaf: false, vmaf_path: None, vmaf_res: "1920x1080", vmaf_threads: None, vmaf_filter: None } }}:ffmpeg{[3mtemp[0m[2m=[0m"temporary" [3moutput[0m[2m=[0m"a_svt-av1.mkv"}: av1an_core::concat: av1an-core\src\concat.rs:338: FFmpeg concat command: "ffmpeg" "-y" "-hide_banner" "-loglevel" "error" "-f" "concat" "-safe" "0" "-i" "\\\\?\\C:\\test\\temporary\\concat" "-i" "\\\\?\\C:\\test\\temporary\\audio.mkv" "-map" "0" "-map" "1" "-c" "copy" "a_svt-av1.mkv"

```

</details>

```
> av1an.exe -i a.mkv --temp temporary --keep -w 2 -e svt-av1 --pix-format yuv420p -s a.json --sc-method fast --sc-downscale-height 720 -m ffms2 -y --verbose -l after.log --target-quality 95
2025-04-27T14:54:52.735966Z  INFO av1an_core::logging: Logging system initialized
2025-04-27T14:54:53.325324Z  INFO encode_file: av1an_core::context: Input: 720x480 @ 29.970 fps, YUV420P, SDR
2025-04-27T14:54:53.989076Z  INFO encode_file: av1an_core::context:
Queue 6 Workers 2 Encoder svt-av1 Passes 1
Params: --preset 4 --keyint 0 --scd 0 --rc 0 --crf 25
[Chunk 0] Encoding frame   36 1791.47 kbps 13.52 fps
[Chunk 1] Encoding frame   48 2070.67 kbps 15.95 fps
00:00:38 ▐█████████████████████████████████████████████████▌ 100% 363/363 (9.41 fps, eta 0s, 2022.6 Kbps, est. 3.27 MiB)
```

<details>
<summary>
after.log
</summary>

```
2025-04-27T14:54:52.735899Z  INFO main ThreadId(01) av1an_core::logging: av1an-core\src\logging.rs:163: Logging system initialized
2025-04-27T14:54:52.736446Z DEBUG main ThreadId(01) av1an_core::logging: av1an-core\src\logging.rs:164: Module-specific logging enabled
2025-04-27T14:54:53.318034Z DEBUG main ThreadId(01) new{args=EncodeArgs { input: Video { path: "a.mkv" }, temp: "temporary", output_file: "a_svt-av1.mkv", chunk_method: FFMS2, chunk_order: LongestFirst, scaler: "bicubic+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact", scenes: Some("a.json"), split_method: AvScenechange, sc_pix_format: None, sc_method: Fast, sc_only: false, sc_downscale_height: Some(720), extra_splits_len: Some(299), min_scene_len: 24, force_keyframes: [], ignore_frame_mismatch: false, max_tries: 3, passes: 1, video_params: [], tiles: (1, 1), encoder: svt_av1, workers: 2, set_thread_affinity: None, photon_noise: None, photon_noise_size: (None, None), chroma_noise: false, zones: None, ffmpeg_filter_args: [], audio_params: ["-c:a", "copy"], input_pix_format: FFmpeg { format: YUV420P }, output_pix_format: PixelFormat { format: YUV420P, bit_depth: 8 }, verbosity: Verbose, log_file: "after.log", log_level: LevelFilter::DEBUG, resume: false, keep: true, force: false, no_defaults: false, tile_auto: false, concat: FFmpeg, target_quality: Some(TargetQuality { vmaf_res: "1920x1080", vmaf_scaler: "bicubic", vmaf_filter: None, vmaf_threads: 8, model: None, probing_rate: 1, probes: 4, target: 95.0, min_q: 15, max_q: 50, encoder: svt_av1, pix_format: YUV420P, temp: "temporary", workers: 2, video_params: [], vspipe_args: [], probe_slow: false }), vmaf: false, vmaf_path: None, vmaf_res: "1920x1080", vmaf_threads: None, vmaf_filter: None }}:initialize{self=Av1anContext { frames: 0, vs_script: None, vs_scd_script: None, args: EncodeArgs { input: Video { path: "a.mkv" }, temp: "temporary", output_file: "a_svt-av1.mkv", chunk_method: FFMS2, chunk_order: LongestFirst, scaler: "bicubic+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact", scenes: Some("a.json"), split_method: AvScenechange, sc_pix_format: None, sc_method: Fast, sc_only: false, sc_downscale_height: Some(720), extra_splits_len: Some(299), min_scene_len: 24, force_keyframes: [], ignore_frame_mismatch: false, max_tries: 3, passes: 1, video_params: ["--preset", "4", "--keyint", "0", "--scd", "0", "--rc", "0", "--crf", "25"], tiles: (1, 1), encoder: svt_av1, workers: 2, set_thread_affinity: None, photon_noise: None, photon_noise_size: (None, None), chroma_noise: false, zones: None, ffmpeg_filter_args: [], audio_params: ["-c:a", "copy"], input_pix_format: FFmpeg { format: YUV420P }, output_pix_format: PixelFormat { format: YUV420P, bit_depth: 8 }, verbosity: Verbose, log_file: "after.log", log_level: LevelFilter::DEBUG, resume: false, keep: true, force: false, no_defaults: false, tile_auto: false, concat: FFmpeg, target_quality: Some(TargetQuality { vmaf_res: "1920x1080", vmaf_scaler: "bicubic", vmaf_filter: None, vmaf_threads: 8, model: None, probing_rate: 1, probes: 4, target: 95.0, min_q: 15, max_q: 50, encoder: svt_av1, pix_format: YUV420P, temp: "temporary", workers: 2, video_params: [], vspipe_args: [], probe_slow: false }), vmaf: false, vmaf_path: None, vmaf_res: "1920x1080", vmaf_threads: None, vmaf_filter: None } }}: av1an_core::context: av1an-core\src\context.rs:82: temporary directory: temporary
2025-04-27T14:54:53.325300Z  INFO main ThreadId(01) encode_file: av1an_core::context: av1an-core\src\context.rs:199: Input: 720x480 @ 29.970 fps, YUV420P, SDR
2025-04-27T14:54:53.989049Z  INFO main ThreadId(01) encode_file: av1an_core::context: av1an-core\src\context.rs:273: 
[1;32mQ[0m[32mueue[0m [1;32m6[0m [1;34mW[0m[34morkers[0m [1;34m2[0m [1;35mE[0m[35mncoder[0m [1;35msvt-av1[0m [1;35mP[0m[35masses[0m [1;35m1[0m
[1mParams[0m: [2m--preset 4 --keyint 0 --scd 0 --rc 0 --crf 25[0m
2025-04-27T14:55:03.185609Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00003"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:356: chunk 00003: P-Rate=1, 75 frames
2025-04-27T14:55:03.185644Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00003"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:360: chunk 00003: TQ-Probes: [(83.40, 15), (75.33, 32)] Early Skip Low Q
2025-04-27T14:55:03.185654Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00003"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:370: chunk 00003: Target Q=15, VMAF=83.40
2025-04-27T14:55:03.185668Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00003"}: av1an_core::broker: av1an-core\src\broker.rs:181:  started chunk 00003: 75 frames
2025-04-27T14:55:05.309831Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00002"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:356: chunk 00002: P-Rate=1, 84 frames
2025-04-27T14:55:05.309853Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00002"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:360: chunk 00002: TQ-Probes: [(80.35, 15), (70.67, 32)] Early Skip Low Q
2025-04-27T14:55:05.309860Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00002"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:370: chunk 00002: Target Q=15, VMAF=80.35
2025-04-27T14:55:05.309865Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00002"}: av1an_core::broker: av1an-core\src\broker.rs:181:  started chunk 00002: 84 frames
2025-04-27T14:55:08.122539Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00003"}: av1an_core::broker: av1an-core\src\broker.rs:238: finished chunk 00003: 75 frames, 5.31 fps, took 14.12s
2025-04-27T14:55:10.849240Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00002"}: av1an_core::broker: av1an-core\src\broker.rs:238: finished chunk 00002: 84 frames, 4.98 fps, took 16.86s
2025-04-27T14:55:16.293815Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00004"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:356: chunk 00004: P-Rate=1, 60 frames
2025-04-27T14:55:16.293834Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00004"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:360: chunk 00004: TQ-Probes: [(83.76, 15), (66.37, 32)] Early Skip Low Q
2025-04-27T14:55:16.293849Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00004"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:370: chunk 00004: Target Q=15, VMAF=83.76
2025-04-27T14:55:16.293852Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00004"}: av1an_core::broker: av1an-core\src\broker.rs:181:  started chunk 00004: 60 frames
2025-04-27T14:55:18.987523Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00005"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:356: chunk 00005: P-Rate=1, 60 frames
2025-04-27T14:55:18.987549Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00005"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:360: chunk 00005: TQ-Probes: [(91.56, 15), (85.60, 32)] Early Skip Low Q
2025-04-27T14:55:18.987570Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00005"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:370: chunk 00005: Target Q=15, VMAF=91.56
2025-04-27T14:55:18.987574Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00005"}: av1an_core::broker: av1an-core\src\broker.rs:181:  started chunk 00005: 60 frames
2025-04-27T14:55:22.271206Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00004"}: av1an_core::broker: av1an-core\src\broker.rs:238: finished chunk 00004: 60 frames, 4.24 fps, took 14.15s
2025-04-27T14:55:22.882036Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00005"}: av1an_core::broker: av1an-core\src\broker.rs:238: finished chunk 00005: 60 frames, 4.99 fps, took 12.03s
2025-04-27T14:55:28.224019Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00001"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:356: chunk 00001: P-Rate=1, 48 frames
2025-04-27T14:55:28.224045Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00001"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:360: chunk 00001: TQ-Probes: [(91.45, 15), (82.48, 32)] Early Skip Low Q
2025-04-27T14:55:28.224057Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00001"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:370: chunk 00001: Target Q=15, VMAF=91.45
2025-04-27T14:55:28.224062Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00001"}: av1an_core::broker: av1an-core\src\broker.rs:181:  started chunk 00001: 48 frames
2025-04-27T14:55:29.212636Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00000"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:356: chunk 00000: P-Rate=1, 36 frames
2025-04-27T14:55:29.212656Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00000"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:360: chunk 00000: TQ-Probes: [(85.93, 15), (77.21, 32)] Early Skip Low Q
2025-04-27T14:55:29.212663Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00000"}: av1an_core::target_quality: av1an-core\src\target_quality.rs:370: chunk 00000: Target Q=15, VMAF=85.93
2025-04-27T14:55:29.212667Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00000"}: av1an_core::broker: av1an-core\src\broker.rs:181:  started chunk 00000: 36 frames
2025-04-27T14:55:32.220238Z DEBUG ThreadId(08) encode_chunk{worker_id=1 chunk_index="00001"}: av1an_core::broker: av1an-core\src\broker.rs:238: finished chunk 00001: 48 frames, 4.83 fps, took 9.94s
2025-04-27T14:55:32.556333Z DEBUG ThreadId(07) encode_chunk{worker_id=0 chunk_index="00000"}: av1an_core::broker: av1an-core\src\broker.rs:238: finished chunk 00000: 36 frames, 3.73 fps, took 9.66s
2025-04-27T14:55:32.559961Z DEBUG main ThreadId(01) encode_file: av1an_core::context: av1an-core\src\context.rs:335: encoding finished, concatenating with ffmpeg
2025-04-27T14:55:32.560956Z DEBUG main ThreadId(01) encode_file:ffmpeg{temp="temporary" output="a_svt-av1.mkv"}: av1an_core::concat: av1an-core\src\concat.rs:338: FFmpeg concat command: "ffmpeg" "-y" "-hide_banner" "-loglevel" "error" "-f" "concat" "-safe" "0" "-i" "\\\\?\\C:\\test\\temporary\\concat" "-i" "\\\\?\\C:\\test\\temporary\\audio.mkv" "-map" "0" "-map" "1" "-c" "copy" "a_svt-av1.mkv"
```

</details>

Target Quality Feedback Example (See Chunk 4):
```
av1an.exe -i a.mkv --temp temporary --keep -w 2 -e svt-av1 --pix-format yuv420p -s a.json --sc-method fast --sc-downscale-height 720 -m ffms2 -y --verbose --target-quality 95
2025-04-27T15:16:07.299194Z  INFO av1an_core::logging: Logging system initialized
2025-04-27T15:16:07.477574Z  INFO encode_file: av1an_core::context: Input: 720x480 @ 29.970 fps, YUV420P, SDR
2025-04-27T15:16:07.692491Z  INFO encode_file: av1an_core::context:
Queue 6 Workers 2 Encoder svt-av1 Passes 1
Params: --preset 4 --keyint 0 --scd 0 --rc 0 --crf 25
[Chunk 2] Encoding frame   49 896.85 kbps 15.01 fps
[Chunk 4] Targeting Quality: 95
00:00:16 ▐████████████████░                               ▌  34% 124/363 (7.36 fps, eta 32s, 1135.3 Kbps, est. 1.99 MiB)
```

Thanks,
\- Boats M.