### PR TITLE
Further changes to console logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ Upload.sh
 
 *.png
 *.json
+
+logs/

--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -279,6 +279,7 @@ impl Broker<'_> {
       chunk.frame_rate,
       self.project.frames,
       self.project.args.verbosity,
+      (get_done().done.len() as u32, self.chunk_queue.len() as u32),
     );
 
     debug!(

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -35,7 +35,7 @@ pub fn av_scenechange_detect(
     } else {
       eprintln!("Scene detection");
     }
-    progress_bar::init_progress_bar(total_frames as u64, 0);
+    progress_bar::init_progress_bar(total_frames as u64, 0, None);
   }
 
   let input2 = input.clone();

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, bail, ensure, Context};
 use av1an_core::concat::ConcatMethod;
 use av1an_core::context::Av1anContext;
 use av1an_core::encoder::Encoder;
-use av1an_core::logging::{init_logging, DEFAULT_CONSOLE_LEVEL, DEFAULT_LOG_LEVEL};
+use av1an_core::logging::{init_logging, DEFAULT_LOG_LEVEL};
 use av1an_core::settings::{EncodeArgs, InputPixelFormat, PixelFormat};
 use av1an_core::target_quality::{adapt_probing_rate, TargetQuality};
 use av1an_core::util::read_in_dir;
@@ -898,8 +898,8 @@ pub fn run() -> anyhow::Result<()> {
 
   init_logging(
     match first_arg.verbosity {
-      Verbosity::Quiet => LevelFilter::OFF,
-      Verbosity::Normal => DEFAULT_CONSOLE_LEVEL,
+      Verbosity::Quiet => LevelFilter::WARN,
+      Verbosity::Normal => LevelFilter::INFO,
       Verbosity::Verbose => LevelFilter::INFO,
     },
     first_arg.log_file.clone(),


### PR DESCRIPTION
This changeset:
- Moves the console logs from stdout to stderr
- Readds the printing of number of chunks and encoder params to the default log level
- Adds a chunks counter to the progress bar

I would like to hide the span that gets printed on each log line, but I could not find a way to do this since we are using tracing_subscriber's layers to set up the logging.

Default:
![Screenshot_20250428_111207](https://github.com/user-attachments/assets/61f473d8-7dbd-4072-9449-23fd0a72758f)

Verbose:
![Screenshot_20250428_111604](https://github.com/user-attachments/assets/b9501c75-8012-4858-ae41-ecb5d502d82a)
