### PR TITLE
Move tracing instrumentation to debug

### DIFF
--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -36,7 +36,7 @@ impl Display for ConcatMethod {
   }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn sort_files_by_filename(files: &mut [PathBuf]) {
   files.sort_unstable_by_key(|x| {
     // If the temp directory follows the expected format of 00000.ivf, 00001.ivf, etc.,
@@ -50,7 +50,7 @@ pub fn sort_files_by_filename(files: &mut [PathBuf]) {
   });
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn ivf(input: &Path, out: &Path) -> anyhow::Result<()> {
   let mut files: Vec<PathBuf> = read_in_dir(input)?.collect();
 
@@ -139,7 +139,7 @@ pub fn ivf(input: &Path, out: &Path) -> anyhow::Result<()> {
   Ok(())
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 fn read_encoded_chunks(encode_dir: &Path) -> anyhow::Result<Vec<DirEntry>> {
   Ok(
     fs::read_dir(encode_dir)
@@ -148,7 +148,7 @@ fn read_encoded_chunks(encode_dir: &Path) -> anyhow::Result<Vec<DirEntry>> {
   )
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn mkvmerge(
   temp_dir: &Path,
   output: &Path,
@@ -226,7 +226,7 @@ pub fn mkvmerge(
 }
 
 /// Create mkvmerge options.json
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn mkvmerge_options_json(
   num: usize,
   encoder: Encoder,
@@ -248,7 +248,7 @@ pub fn mkvmerge_options_json(
 }
 
 /// Concatenates using ffmpeg (does not work with x265)
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn ffmpeg(temp: &Path, output: &Path) -> anyhow::Result<()> {
   fn write_concat_file(temp_folder: &Path) -> anyhow::Result<()> {
     let concat_file = temp_folder.join("concat");

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -51,7 +51,7 @@ pub struct Av1anContext {
 }
 
 impl Av1anContext {
-  #[tracing::instrument]
+  #[tracing::instrument(level = "debug")]
   pub fn new(mut args: EncodeArgs) -> anyhow::Result<Self> {
     args.validate()?;
     let mut this = Self {
@@ -65,14 +65,14 @@ impl Av1anContext {
   }
 
   /// Initialize logging routines and create temporary directories
-  #[tracing::instrument]
+  #[tracing::instrument(level = "debug")]
   fn initialize(&mut self) -> anyhow::Result<()> {
     ffmpeg::init()?;
     ffmpeg::util::log::set_level(ffmpeg::util::log::level::Level::Fatal);
 
     if !self.args.resume && Path::new(&self.args.temp).is_dir() {
       fs::remove_dir_all(&self.args.temp)
-        .with_context(|| format!("Failed to remove temporary directory {:?}", &self.args.temp))?;
+        .with_context(|| format!("Failed to remove temporary directory {}", self.args.temp))?;
     }
 
     create_dir!(Path::new(&self.args.temp))?;
@@ -91,22 +91,22 @@ impl Av1anContext {
         (true, true) => {}
         (false, true) => {
           info!(
-            "resume was set but done.json does not exist in temporary directory {:?}",
-            &self.args.temp
+            "resume was set but done.json does not exist in temporary directory {}",
+            self.args.temp
           );
           self.args.resume = false;
         }
         (true, false) => {
           info!(
-            "resume was set but chunks.json does not exist in temporary directory {:?}",
-            &self.args.temp
+            "resume was set but chunks.json does not exist in temporary directory {}",
+            self.args.temp
           );
           self.args.resume = false;
         }
         (false, false) => {
           info!(
-            "resume was set but neither chunks.json nor done.json exist in temporary directory {:?}",
-            &self.args.temp
+            "resume was set but neither chunks.json nor done.json exist in temporary directory {}",
+            self.args.temp
           );
           self.args.resume = false;
         }
@@ -428,7 +428,7 @@ impl Av1anContext {
     Ok(())
   }
 
-  #[tracing::instrument]
+  #[tracing::instrument(level = "debug")]
   fn read_queue_files(source_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
     let mut queue_files = fs::read_dir(source_path)
       .with_context(|| format!("Failed to read queue files from source path {source_path:?}"))?
@@ -1147,7 +1147,7 @@ impl Av1anContext {
     Ok(chunk_queue)
   }
 
-  #[tracing::instrument]
+  #[tracing::instrument(level = "debug")]
   fn create_chunk_from_segment(
     &self,
     index: usize,

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -32,7 +32,7 @@ pub enum Encoder {
   x265,
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub(crate) fn parse_svt_av1_version(version: &[u8]) -> Option<(u32, u32, u32)> {
   let v_idx = memchr::memchr(b'v', version)?;
   let s = version.get(v_idx + 1..)?;

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -40,7 +40,7 @@ pub fn compose_ffmpeg_pipe<S: Into<String>>(
 }
 
 /// Get frame count using FFmpeg
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn num_frames(source: &Path) -> Result<usize, ffmpeg::Error> {
   let mut ictx = input(source)?;
   let input = ictx
@@ -58,7 +58,7 @@ pub fn num_frames(source: &Path) -> Result<usize, ffmpeg::Error> {
   )
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn frame_rate(source: &Path) -> Result<f64, ffmpeg::Error> {
   let ictx = input(source)?;
   let input = ictx
@@ -69,7 +69,7 @@ pub fn frame_rate(source: &Path) -> Result<f64, ffmpeg::Error> {
   Ok(f64::from(rate.numerator()) / f64::from(rate.denominator()))
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn get_pixel_format(source: &Path) -> Result<Pixel, ffmpeg::Error> {
   let ictx = ffmpeg::format::input(source)?;
 
@@ -85,7 +85,7 @@ pub fn get_pixel_format(source: &Path) -> Result<Pixel, ffmpeg::Error> {
   Ok(decoder.format())
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn resolution(source: &Path) -> Result<(u32, u32), ffmpeg::Error> {
   let ictx = ffmpeg::format::input(source)?;
 
@@ -101,7 +101,7 @@ pub fn resolution(source: &Path) -> Result<(u32, u32), ffmpeg::Error> {
   Ok((decoder.width(), decoder.height()))
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn transfer_characteristics(source: &Path) -> Result<TransferCharacteristic, ffmpeg::Error> {
   let ictx = ffmpeg::format::input(source)?;
 
@@ -118,7 +118,7 @@ pub fn transfer_characteristics(source: &Path) -> Result<TransferCharacteristic,
 }
 
 /// Returns vec of all keyframes
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn get_keyframes(source: &Path) -> Result<Vec<usize>, ffmpeg::Error> {
   let mut ictx = input(source)?;
   let input = ictx

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -15,7 +15,7 @@ use smallvec::{smallvec, SmallVec};
 use crate::scenes::Scene;
 use crate::{into_smallvec, progress_bar, Encoder, Input, ScenecutMethod, Verbosity};
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 #[allow(clippy::too_many_arguments)]
 pub fn av_scenechange_detect(
   input: &Input,
@@ -204,7 +204,7 @@ pub fn scene_detect(
   Ok(scenes)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 fn build_decoder(
   input: &Input,
   encoder: Encoder,

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -599,7 +599,7 @@ pub struct CliOpts {
 }
 
 impl CliOpts {
-  #[tracing::instrument]
+  #[tracing::instrument(level = "debug")]
   pub fn target_quality_params(
     &self,
     temp_dir: String,
@@ -677,7 +677,7 @@ pub(crate) fn resolve_file_paths(path: &Path) -> anyhow::Result<Box<dyn Iterator
 }
 
 /// Returns vector of Encode args ready to be fed to encoder
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
   let input_paths = &*args.input;
 


### PR DESCRIPTION
I found that the big blobs of debug info that were being printed on certain log lines, e.g. the resume logs, were a result of `tracing::instrument`. This change moves those all to debug level, so they are not printed to the console by default. This also cleans up a few other minor items, which are not necessary, but I already cleaned them up while debugging so I figured they are worth keeping.