### PR TITLE
Fix issue where chunk progress is inaccurate on resume

### DIFF
--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -228,8 +228,8 @@ impl Av1anContext {
       info!(
         "encoding resumed with {}/{} chunks completed ({} remaining)",
         chunks_done,
-        total_chunks + chunks_done,
-        total_chunks
+        total_chunks,
+        chunk_queue.len()
       );
     }
 
@@ -325,7 +325,7 @@ impl Av1anContext {
 
       let (tx, rx) = mpsc::channel();
       let handle = s.spawn(|_| {
-        broker.encoding_loop(tx, self.args.set_thread_affinity);
+        broker.encoding_loop(tx, self.args.set_thread_affinity, total_chunks as u32);
       });
 
       // Queue::encoding_loop only sends a message if there was an error (meaning a chunk crashed)


### PR DESCRIPTION
When resuming, there is an issue where the total chunk count on the progress bar was incorrect. This was only affecting the progress bar and not the actual encode.