### PR TITLE
Cleanup and inline public exports

### DIFF
--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -99,3 +99,7 @@ vapoursynth_new_api = [
     "vapoursynth/vapoursynth-api-32",
     "vapoursynth/vsscript-api-31",
 ]
+
+[lints.clippy]
+inline_always = "warn"
+missing_inline_in_public_items = "warn"

--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -45,6 +45,7 @@ pub enum ConcatMethod {
 }
 
 impl Display for ConcatMethod {
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(<&'static str>::from(self))
     }

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -23,7 +23,6 @@ use std::{
 use ansi_term::{Color, Style};
 use anyhow::{bail, Context};
 use av1_grain::TransferFunction;
-use crossbeam_utils;
 use itertools::Itertools;
 use num_traits::cast::ToPrimitive;
 use rand::{prelude::SliceRandom, rng};
@@ -175,6 +174,7 @@ impl Av1anContext {
     }
 
     #[tracing::instrument(skip(self))]
+    #[inline]
     pub fn encode_file(&mut self) -> anyhow::Result<()> {
         let initial_frames =
             get_done().done.iter().map(|ref_multi| ref_multi.frames).sum::<usize>();
@@ -467,6 +467,7 @@ impl Av1anContext {
 
     /// Returns the number of frames encoded if crashed, to reset the progress
     /// bar.
+    #[inline]
     pub fn create_pipes(
         &self,
         chunk: &Chunk,

--- a/av1an-core/src/encoder.rs
+++ b/av1an-core/src/encoder.rs
@@ -73,6 +73,7 @@ pub static USE_OLD_SVT_AV1: Lazy<bool> = Lazy::new(|| {
 });
 
 impl Display for Encoder {
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(<&'static str>::from(self))
     }
@@ -80,6 +81,7 @@ impl Display for Encoder {
 
 impl Encoder {
     /// Composes 1st pass command for 1 pass encoding
+    #[inline]
     pub fn compose_1_1_pass(self, params: Vec<String>, output: String) -> Vec<String> {
         match self {
             Self::aom => chain!(into_array!["aomenc", "--passes=1"], params, into_array![
@@ -114,6 +116,7 @@ impl Encoder {
     }
 
     /// Composes 1st pass command for 2 pass encoding
+    #[inline]
     pub fn compose_1_2_pass(self, params: Vec<String>, fpf: &str) -> Vec<String> {
         match self {
             Self::aom => chain!(
@@ -190,6 +193,7 @@ impl Encoder {
     }
 
     /// Composes 2st pass command for 2 pass encoding
+    #[inline]
     pub fn compose_2_2_pass(self, params: Vec<String>, fpf: &str, output: String) -> Vec<String> {
         match self {
             Self::aom => chain!(
@@ -266,6 +270,7 @@ impl Encoder {
     }
 
     /// Returns default settings for the encoder
+    #[inline]
     pub fn get_default_arguments(self, (cols, rows): (u32, u32)) -> Vec<String> {
         /// Integer log base 2
         pub const fn ilog2(x: u32) -> u32 {
@@ -402,6 +407,7 @@ impl Encoder {
     }
 
     /// Return number of default passes for encoder
+    #[inline]
     pub const fn get_default_pass(self) -> u8 {
         match self {
             Self::aom | Self::vpx => 2,
@@ -410,6 +416,7 @@ impl Encoder {
     }
 
     /// Default quantizer range target quality mode
+    #[inline]
     pub const fn get_default_cq_range(self) -> (usize, usize) {
         match self {
             Self::aom | Self::vpx => (15, 55),
@@ -420,6 +427,7 @@ impl Encoder {
     }
 
     /// Returns help command for encoder
+    #[inline]
     pub const fn help_command(self) -> [&'static str; 2] {
         match self {
             Self::aom => ["aomenc", "--help"],
@@ -433,6 +441,7 @@ impl Encoder {
 
     /// Returns version text for encoder, or None if encoder is not available in
     /// PATH
+    #[inline]
     pub fn version_text(self) -> Option<String> {
         match self {
             Self::aom => {
@@ -491,6 +500,7 @@ impl Encoder {
     }
 
     /// Get the name of the executable/binary for the encoder
+    #[inline]
     pub const fn bin(self) -> &'static str {
         match self {
             Self::aom => "aomenc",
@@ -503,6 +513,7 @@ impl Encoder {
     }
 
     /// Get the name of the video format associated with the encoder
+    #[inline]
     pub const fn format(self) -> &'static str {
         match self {
             Self::aom | Self::rav1e | Self::svt_av1 => "av1",
@@ -513,6 +524,7 @@ impl Encoder {
     }
 
     /// Get the default output extension for the encoder
+    #[inline]
     pub const fn output_extension(&self) -> &'static str {
         match &self {
             Self::aom | Self::rav1e | Self::vpx | Self::svt_av1 => "ivf",
@@ -557,6 +569,7 @@ impl Encoder {
     }
 
     /// Returns changed q/crf in command line arguments
+    #[inline]
     pub fn man_command(self, mut params: Vec<String>, q: usize) -> Vec<String> {
         let index = list_index(&params, self.q_match_fn());
         if let Some(index) = index {
@@ -593,6 +606,7 @@ impl Encoder {
     }
 
     /// Returns command used for target quality probing
+    #[inline]
     pub fn construct_target_quality_command(
         self,
         threads: usize,
@@ -781,6 +795,7 @@ impl Encoder {
 
     /// Returns command used for target quality probing (slow, correctness
     /// focused version)
+    #[inline]
     pub fn construct_target_quality_command_probe_slow(self, q: usize) -> Vec<Cow<'static, str>> {
         match &self {
             Self::aom => inplace_vec!["aomenc", "--passes=1", format!("--cq-level={q}")],
@@ -821,6 +836,7 @@ impl Encoder {
 
     /// Function `remove_patterns` that takes in args and patterns and removes
     /// all instances of the patterns from the args.
+    #[inline]
     pub fn remove_patterns(args: &mut Vec<String>, patterns: &[&str]) {
         for pattern in patterns {
             if let Some(index) = args.iter().position(|value| value.contains(pattern)) {
@@ -834,6 +850,7 @@ impl Encoder {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[inline]
     /// Constructs tuple of commands for target quality probing
     pub fn probe_cmd(
         self,
@@ -883,6 +900,7 @@ impl Encoder {
         (pipe, output)
     }
 
+    #[inline]
     pub fn get_format_bit_depth(self, format: Pixel) -> Result<usize, UnsupportedPixelFormatError> {
         macro_rules! impl_this_function {
       ($($encoder:ident),*) => {

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -15,6 +15,7 @@ use path_abs::{PathAbs, PathInfo};
 
 use crate::{into_array, into_vec};
 
+#[inline]
 pub fn compose_ffmpeg_pipe<S: Into<String>>(
     params: impl IntoIterator<Item = S>,
     pix_format: Pixel,
@@ -126,6 +127,8 @@ pub fn get_keyframes(source: &Path) -> Result<Vec<usize>, ffmpeg::Error> {
 }
 
 /// Returns true if input file have audio in it
+#[must_use]
+#[inline]
 pub fn has_audio(file: &Path) -> bool {
     let ictx = input(file).unwrap();
     ictx.streams().best(MediaType::Audio).is_some()
@@ -136,6 +139,7 @@ pub fn has_audio(file: &Path) -> bool {
 /// This function returns `Some(output)` if the audio exists and the audio
 /// successfully encoded, or `None` otherwise.
 #[must_use]
+#[inline]
 pub fn encode_audio<S: AsRef<OsStr>>(
     input: impl AsRef<Path> + std::fmt::Debug,
     temp: impl AsRef<Path> + std::fmt::Debug,
@@ -173,6 +177,7 @@ pub fn encode_audio<S: AsRef<OsStr>>(
 }
 
 /// Escapes paths in ffmpeg filters if on windows
+#[inline]
 pub fn escape_path_in_filter(path: impl AsRef<Path>) -> String {
     if cfg!(windows) {
         PathAbs::new(path.as_ref())

--- a/av1an-core/src/logging.rs
+++ b/av1an-core/src/logging.rs
@@ -39,6 +39,7 @@ impl Default for ModuleConfig {
 }
 
 /// Initialize logging with per-module configuration
+#[inline]
 pub fn init_logging(console_level: LevelFilter, log_path: PathBuf, file_level: LevelFilter) {
     // Set up our module configurations
     let mut module_configs = HashMap::new();

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -37,10 +37,6 @@ pub fn get_audio_size() -> u64 {
     *AUDIO_BYTES.get().unwrap_or(&0u64)
 }
 
-pub fn get_progress_bar() -> Option<&'static ProgressBar> {
-    PROGRESS_BAR.get()
-}
-
 fn pretty_progress_style(resume_frames: u64) -> ProgressStyle {
     ProgressStyle::default_bar()
         .template(INDICATIF_PROGRESS_TEMPLATE)
@@ -181,14 +177,6 @@ pub fn finish_progress_bar() {
 }
 
 static MULTI_PROGRESS_BAR: OnceCell<(MultiProgress, Vec<ProgressBar>)> = OnceCell::new();
-
-pub fn get_first_multi_progress_bar() -> Option<&'static ProgressBar> {
-    if let Some((_, pbars)) = MULTI_PROGRESS_BAR.get() {
-        pbars.first()
-    } else {
-        None
-    }
-}
 
 pub fn set_len(len: u64) {
     let pb = PROGRESS_BAR.get().unwrap();

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -104,6 +104,7 @@ pub struct EncodeArgs {
 }
 
 impl EncodeArgs {
+    #[inline]
     pub fn validate(&mut self) -> anyhow::Result<()> {
         if self.concat == ConcatMethod::Ivf
             && !matches!(

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -280,6 +280,7 @@ impl TargetQuality {
         Ok(fl_path)
     }
 
+    #[inline]
     pub fn per_shot_target_quality_routine(
         &self,
         chunk: &mut Chunk,
@@ -392,6 +393,7 @@ pub fn log_probes(
     );
 }
 
+#[inline]
 pub const fn adapt_probing_rate(rate: usize) -> usize {
     match rate {
         1..=4 => rate,

--- a/av1an-core/src/util.rs
+++ b/av1an-core/src/util.rs
@@ -126,6 +126,7 @@ pub(crate) fn printable_base10_digits(x: usize) -> u32 {
 
 /// Reads dir and returns all files
 /// Depth 1
+#[inline]
 pub fn read_in_dir(path: &Path) -> anyhow::Result<impl Iterator<Item = PathBuf>> {
     let dir = std::fs::read_dir(path)?;
     Ok(dir.into_iter().filter_map(Result::ok).filter_map(|d| {

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -34,6 +34,7 @@ static VAPOURSYNTH_PLUGINS: Lazy<HashSet<String>> = Lazy::new(|| {
         .collect()
 });
 
+#[inline]
 pub fn is_lsmash_installed() -> bool {
     static LSMASH_PRESENT: Lazy<bool> =
         Lazy::new(|| VAPOURSYNTH_PLUGINS.contains("systems.innocent.lsmas"));
@@ -41,6 +42,7 @@ pub fn is_lsmash_installed() -> bool {
     *LSMASH_PRESENT
 }
 
+#[inline]
 pub fn is_ffms2_installed() -> bool {
     static FFMS2_PRESENT: Lazy<bool> =
         Lazy::new(|| VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.ffms2"));
@@ -48,6 +50,7 @@ pub fn is_ffms2_installed() -> bool {
     *FFMS2_PRESENT
 }
 
+#[inline]
 pub fn is_dgdecnv_installed() -> bool {
     static DGDECNV_PRESENT: Lazy<bool> =
         Lazy::new(|| VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.dgdecodenv"));
@@ -55,6 +58,7 @@ pub fn is_dgdecnv_installed() -> bool {
     *DGDECNV_PRESENT
 }
 
+#[inline]
 pub fn is_bestsource_installed() -> bool {
     static BESTSOURCE_PRESENT: Lazy<bool> =
         Lazy::new(|| VAPOURSYNTH_PLUGINS.contains("com.vapoursynth.bestsource"));
@@ -62,6 +66,7 @@ pub fn is_bestsource_installed() -> bool {
     *BESTSOURCE_PRESENT
 }
 
+#[inline]
 pub fn best_available_chunk_method() -> ChunkMethod {
     if is_lsmash_installed() {
         ChunkMethod::LSMASH
@@ -192,6 +197,7 @@ fn get_transfer(env: &Environment) -> anyhow::Result<u8> {
     Ok(transfer)
 }
 
+#[inline]
 pub fn create_vs_file(
     temp: &str,
     source: &Path,
@@ -286,6 +292,7 @@ pub fn create_vs_file(
     Ok(load_script_path)
 }
 
+#[inline]
 pub fn copy_vs_file(
     temp: &str,
     source: &Path,
@@ -320,6 +327,7 @@ pub fn copy_vs_file(
     Ok(scd_script_path)
 }
 
+#[inline]
 pub fn num_frames(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<usize> {
     // Create a new VSScript environment.
     let mut environment = Environment::new().unwrap();
@@ -334,6 +342,7 @@ pub fn num_frames(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<us
     get_num_frames(&environment)
 }
 
+#[inline]
 pub fn bit_depth(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<usize> {
     // Create a new VSScript environment.
     let mut environment = Environment::new().unwrap();
@@ -348,6 +357,7 @@ pub fn bit_depth(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<usi
     get_bit_depth(&environment)
 }
 
+#[inline]
 pub fn frame_rate(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<Rational64> {
     // Create a new VSScript environment.
     let mut environment = Environment::new().unwrap();
@@ -362,6 +372,7 @@ pub fn frame_rate(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<Ra
     get_frame_rate(&environment)
 }
 
+#[inline]
 pub fn resolution(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<(u32, u32)> {
     // Create a new VSScript environment.
     let mut environment = Environment::new().unwrap();
@@ -377,6 +388,7 @@ pub fn resolution(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<(u
 }
 
 /// Transfer characteristics as specified in ITU-T H.265 Table E.4.
+#[inline]
 pub fn transfer_characteristics(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<u8> {
     // Create a new VSScript environment.
     let mut environment = Environment::new().unwrap();
@@ -391,6 +403,7 @@ pub fn transfer_characteristics(source: &Path, vspipe_args_map: OwnedMap) -> any
     get_transfer(&environment)
 }
 
+#[inline]
 pub fn pixel_format(source: &Path, vspipe_args_map: OwnedMap) -> anyhow::Result<String> {
     // Create a new VSScript environment.
     let mut environment = Environment::new().unwrap();

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -10,23 +10,27 @@ use std::{
 use ::ffmpeg::format::Pixel;
 use anyhow::{anyhow, bail, ensure, Context};
 use av1an_core::{
-    concat::ConcatMethod,
-    context::Av1anContext,
-    encoder::Encoder,
+    adapt_probing_rate,
     ffmpeg,
     hash_path,
+    init_logging,
     into_vec,
-    logging::{init_logging, DEFAULT_LOG_LEVEL},
-    settings::{EncodeArgs, InputPixelFormat, PixelFormat},
-    target_quality::{adapt_probing_rate, TargetQuality},
-    util::read_in_dir,
+    read_in_dir,
     vapoursynth,
+    Av1anContext,
     ChunkMethod,
     ChunkOrdering,
+    ConcatMethod,
+    EncodeArgs,
+    Encoder,
     Input,
+    InputPixelFormat,
+    PixelFormat,
     ScenecutMethod,
     SplitMethod,
+    TargetQuality,
     Verbosity,
+    DEFAULT_LOG_LEVEL,
 };
 use clap::{value_parser, Parser};
 use num_traits::cast::ToPrimitive;


### PR DESCRIPTION
- Only make public the items that we actually want to expose for av1an as a library. Right now this is based on any items that are used by av1an's CLI. This may be expanded in the future.
- This allows us to enable a clippy lint for adding `#[inline]` to any public functions. The benefit of this is that those functions can be considered as candidates for inlining in the CLI even if LTO is not enabled.