### PR TITLE
Fix resuming crashes from attempt to subtract with overflow

### DIFF
--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -172,7 +172,7 @@ pub fn mkvmerge(
         let p = p.as_ref().display().to_string();
         if let Some(path) = p.strip_prefix(UNC_PREFIX) {
             if let Some(p2) = path.strip_prefix("UNC") {
-                format!("\\{}", p2)
+                format!("\\{p2}")
             } else {
                 path.to_string()
             }

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -42,7 +42,11 @@ fn pretty_progress_style(resume_frames: u64) -> ProgressStyle {
         .template(INDICATIF_PROGRESS_TEMPLATE)
         .unwrap()
         .with_key("fps", move |state: &ProgressState, w: &mut dyn Write| {
-            let resume_pos = state.pos() - resume_frames;
+            let resume_pos = if state.pos() < resume_frames {
+                resume_frames
+            } else {
+                state.pos() - resume_frames
+            };
             if resume_pos == 0 || state.elapsed().as_secs_f32() < f32::EPSILON {
                 write!(w, "0 fps").unwrap();
             } else {
@@ -57,7 +61,11 @@ fn pretty_progress_style(resume_frames: u64) -> ProgressStyle {
         .with_key(
             "fixed_eta",
             move |state: &ProgressState, w: &mut dyn Write| {
-                let resume_pos = state.pos() - resume_frames;
+                let resume_pos = if state.pos() < resume_frames {
+                    resume_frames
+                } else {
+                    state.pos() - resume_frames
+                };
                 if resume_pos == 0 || state.elapsed().as_secs_f32() < f32::EPSILON {
                     write!(w, "unknown").unwrap();
                 } else {
@@ -86,7 +94,11 @@ fn spinner_style(resume_frames: u64) -> ProgressStyle {
         .template(INDICATIF_SC_SPINNER_TEMPLATE)
         .unwrap()
         .with_key("fps", move |state: &ProgressState, w: &mut dyn Write| {
-            let resume_pos = state.pos() - resume_frames;
+            let resume_pos = if state.pos() < resume_frames {
+                resume_frames
+            } else {
+                state.pos() - resume_frames
+            };
             if resume_pos == 0 || state.elapsed().as_secs_f32() < f32::EPSILON {
                 write!(w, "0 fps").unwrap();
             } else {


### PR DESCRIPTION
This PR adds a check for an unsigned integer underflow condition when initializing a progress bar when resuming. If the condition occurs, the `resume_pos` is set to `resume_frames` instead of attempting to underflow the variable. I don't know why this subtraction occurs, so I have left it as-is when the underflow issue does not occur.

## Debugging Demonstration

Resuming an encode initializes the progress bar with a state position of `0`, which causes the error below:

```ps
av1an -i .\a.mkv --temp resume --keep --resume -e svt-av1 -l logs/resume.log
 INFO encode_file: Input: 1920x1080 @ 23.976 fps, YUV420P, SDR
 INFO encode_file: encoding resumed with 9/19 chunks completed (10 remaining)
 INFO encode_file:
Queue 10 Workers 2 Encoder svt-av1 Passes 1
Params: --preset 4 --keyint 0 --scd 0 --rc 0 --crf 25

thread 'main' panicked at av1an-core\src\progress_bar.rs:45:30:
attempt to subtract with overflow
```

To demonstrate the issue, I added a log for each time this happens in the "fps" `with_key` block:

```rs
fn pretty_progress_style(resume_frames: u64) -> ProgressStyle {
    ProgressStyle::default_bar()
        .template(INDICATIF_PROGRESS_TEMPLATE)
        .unwrap()
        .with_key("fps", move |state: &ProgressState, w: &mut dyn Write| {
            let resume_pos = if state.pos() < resume_frames {
                debug!(
                    "Attempted integer underflow in progress bar:
                POS: {} | RESUME: {} | LEN: {}",
                    state.pos(),
                    resume_frames,
                    state.len().unwrap_or(0)
                );
                resume_frames
            } else {
                state.pos() - resume_frames
            };
...
```

logs/resume.log
```
...
2025-05-27T00:06:56.482129Z  INFO encode_file: av1an_core::context: Input: 1920x1080 @ 23.976 fps, YUV420P, SDR
2025-05-27T00:06:56.483421Z  INFO encode_file: av1an_core::context: encoding resumed with 5/19 chunks completed (14 remaining)
2025-05-27T00:06:56.543066Z  INFO encode_file: av1an_core::context: 
[1;32mQ[0m[32mueue[0m [1;32m14[0m [1;34mW[0m[34morkers[0m [1;34m2[0m [1;35mE[0m[35mncoder[0m [1;35msvt-av1[0m [1;35mP[0m[35masses[0m [1;35m1[0m
[1mParams[0m: [2m--preset 4 --keyint 0 --scd 0 --rc 0 --crf 25[0m
2025-05-27T00:06:56.544182Z DEBUG encode_file: av1an_core::progress_bar: Attempted integer underflow in progress bar:
                    POS: 0 | RESUME: 760 | LEN: 1882
2025-05-27T00:06:56.544518Z DEBUG encode_file: av1an_core::progress_bar: Attempted integer underflow in progress bar:
                    POS: 0 | RESUME: 760 | LEN: 1882
2025-05-27T00:06:56.544812Z DEBUG encode_file: av1an_core::progress_bar: Attempted integer underflow in progress bar:
                    POS: 0 | RESUME: 760 | LEN: 1882
2025-05-27T00:06:56.546638Z DEBUG encode_chunk{worker_id=0 total_chunks=19 chunk_index="00007"}: av1an_core::broker:  started chunk 00007: 129 frames
2025-05-27T00:06:56.546745Z DEBUG encode_chunk{worker_id=1 total_chunks=19 chunk_index="00011"}: av1an_core::broker:  started chunk 00011: 129 frames
2025-05-27T00:06:57.580972Z ERROR av1an_core::broker: Shutting down. Waiting for current workers to finish...
...
```

Thanks,
\- Boats M.