### PR TITLE
fix fbba019e: forcing output FPS breaks using FPS changing filter

### DIFF
--- a/av1an-core/src/concat.rs
+++ b/av1an-core/src/concat.rs
@@ -162,7 +162,7 @@ pub fn mkvmerge(
     output: &Path,
     encoder: Encoder,
     num_chunks: usize,
-    output_fps: Rational64,
+    output_fps: Option<Rational64>,
 ) -> anyhow::Result<()> {
     // mkvmerge does not accept UNC paths on Windows
     #[cfg(windows)]
@@ -242,20 +242,24 @@ pub fn mkvmerge_options_json(
     encoder: Encoder,
     output: &str,
     audio: Option<&str>,
-    output_fps: Rational64,
+    output_fps: Option<Rational64>,
 ) -> String {
     let mut file_string = String::with_capacity(64 + 12 * num);
     write!(file_string, "[\"-o\", {output:?}").unwrap();
     if let Some(audio) = audio {
         write!(file_string, ", {audio:?}").unwrap();
     }
-    write!(
-        file_string,
-        ", \"--default-duration\", \"0:{}/{}fps\", \"[\"",
-        output_fps.numer(),
-        output_fps.denom()
-    )
-    .unwrap();
+    if let Some(output_fps) = output_fps {
+        write!(
+            file_string,
+            ", \"--default-duration\", \"0:{}/{}fps\", \"[\"",
+            output_fps.numer(),
+            output_fps.denom()
+        )
+        .unwrap();
+    } else {
+        file_string.push_str(", \"[\"");
+    }
     for i in 0..num {
         write!(
             file_string,

--- a/av1an-core/src/concat/tests.rs
+++ b/av1an-core/src/concat/tests.rs
@@ -4,7 +4,13 @@ use super::*;
 
 #[test]
 fn test_mkvmerge_options_json_no_audio() {
-    let result = mkvmerge_options_json(2, Encoder::aom, "output.mkv", None, Rational64::new(30, 1));
+    let result = mkvmerge_options_json(
+        2,
+        Encoder::aom,
+        "output.mkv",
+        None,
+        Some(Rational64::new(30, 1)),
+    );
     assert_eq!(
         result,
         r#"["-o", "output.mkv", "--default-duration", "0:30/1fps", "[", "00000.ivf", "00001.ivf","]"]"#
@@ -18,7 +24,7 @@ fn test_mkvmerge_options_json_with_audio() {
         Encoder::aom,
         "output.mkv",
         Some("audio.mkv"),
-        Rational64::new(30, 1),
+        Some(Rational64::new(30, 1)),
     );
     assert_eq!(
         result,

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -391,7 +391,19 @@ impl Av1anContext {
                         self.args.output_file.as_ref(),
                         self.args.encoder,
                         total_chunks,
-                        fps_ratio,
+                        if self.args.ignore_frame_mismatch {
+                            info!(
+                                "`--ignore-frame-mismatch` set. Don't force output FPS, as an FPS \
+                                 changing filter might have been applied."
+                            );
+                            None
+                        } else {
+                            debug!(
+                                "`--ignore-frame-mismatch` not set. Forcing output FPS to \
+                                 {fps_ratio} with mkvmerge."
+                            );
+                            Some(fps_ratio)
+                        },
                     )?;
                 },
                 ConcatMethod::FFmpeg => {


### PR DESCRIPTION
Hi,

I use FFmpeg on an input filter to change fps of some of my clips: `--ignore-frame-mismatch --ffmpeg "-vf scale=-1:\\'min(ih,1080)\\':flags=lanczos,fps=15"`. After updating to newest master I found that fbba019e broke my method: since now, the output muxer is forced unconditionally to emit videos @ input fps, I get a video where e.g. with fps 60->15 The first 25% of the file play the whole video in 4x speed, and the last 75% are still image.

This PR would add a condition to only force output fps if `--ignore-frame-mismatch` is not set, since if you want to change output fps with FFmpeg you have to use this flag. I would also be down to add a flag to av1an to control fps forcing, or --- maybe even better --- add a flag to change fps directly through Av1an. This would additionally provide accurate progress bar data, which is broken with this method.

@Maintainers: please tell me which solution you would accept upstream, I will do my best to implement them :)