### PR TITLE
Make codecov not fail CI if coverage decreases

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+﻿coverage:
+  status:
+    project:
+      default:
+        informational: true # Makes status checks informational only
+    patch:
+      default:
+        informational: true # Makes patch coverage informational too


### PR DESCRIPTION
Eventually we would like to get full unit test coverage, but we are not there yet. So for now we just want the coverage reports to be informational.