### PR TITLE
Fix CLI argument validation warnings do not print

### DIFF
--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -11,6 +11,7 @@ use ffmpeg::format::Pixel;
 use itertools::{chain, Itertools};
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::filter::LevelFilter;
+use tracing::warn;
 
 use crate::{
     concat::ConcatMethod,
@@ -227,10 +228,18 @@ impl EncodeArgs {
         }
 
         if self.concat == ConcatMethod::MKVMerge && which::which("mkvmerge").is_err() {
-            bail!(
-                "mkvmerge not found, but `--concat mkvmerge` was specified. Is it installed in \
-                 system path?"
-            );
+            if self.sc_only {
+                warn!(
+                    "mkvmerge not found, but `--concat mkvmerge` was specified. Make sure to \
+                     install mkvmerge or specify a different concatenation method (e.g. `--concat \
+                     ffmpeg`) before encoding."
+                );
+            } else {
+                bail!(
+                    "mkvmerge not found, but `--concat mkvmerge` was specified. Is it installed \
+                     in system path?"
+                );
+            }
         }
 
         if self.encoder == Encoder::x265 && self.concat != ConcatMethod::MKVMerge {
@@ -281,7 +290,7 @@ impl EncodeArgs {
 
         if self.ignore_frame_mismatch {
             warn!(
-                "The output video's frame count may differ, and VMAF calculations may be incorrect"
+                "The output video's frame count may differ, and target metric calculations may be incorrect"
             );
         }
 

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -10,8 +10,8 @@ use anyhow::{bail, ensure};
 use ffmpeg::format::Pixel;
 use itertools::{chain, Itertools};
 use serde::{Deserialize, Serialize};
-use tracing_subscriber::filter::LevelFilter;
 use tracing::warn;
+use tracing_subscriber::filter::LevelFilter;
 
 use crate::{
     concat::ConcatMethod,
@@ -290,7 +290,8 @@ impl EncodeArgs {
 
         if self.ignore_frame_mismatch {
             warn!(
-                "The output video's frame count may differ, and target metric calculations may be incorrect"
+                "The output video's frame count may differ, and target metric calculations may be \
+                 incorrect"
             );
         }
 


### PR DESCRIPTION
Resolves #1003

Instead of bailing (exit with error message), present the user with a warning message (see below) that suggests they install mkvmerge or specify a different concatenation method. This allows users to perform Scene Detection without having to also specify a different concatenation method, which is unrelated to the user's intent.

The `tracing::warn` import was missing from the `settings.rs` file, so this PR also fixes that.

```ps
> av1an.exe -i input.mkv --temp temporary --concat mkvmerge --sc-only
 WARN mkvmerge not found, but `--concat mkvmerge` was specified. Make sure to install mkvmerge or specify a different concatenation method (e.g. `--concat ffmpeg`) before encoding.
 INFO resume was set but neither chunks.json nor done.json exist in temporary directory temporary
 INFO encode_file: Input: 1920x1080 @ 23.976 fps, YUV420P10LE, SDR
Scene detection
00:00:06 ▐████████████████████████████████████████████████████████████████████████████▌ 100% 452/452 (73.83 fps, eta 0s) INFO encode_file: scenecut: found 5 scene(s) [with extra_splits (239 frames): 5 scene(s)]
```

There are many other checks that can fail similarly (such as a missing default "aomenc" encoder), but this PR does not handle every case where this could occur. For that much effort, it would be better spent on rewriting the CLI.

Ideally, this would fall under the large refactor mentioned in Feature Request #995 where the CLI is reorganized. For this specific application, a subcommand would be a better pattern for handling Scene Detection and nothing else. That command would have its own validation that does not rely on extraneous checks.