### PR TITLE
Fix final probe copy shortcut ignores probing rate, probing speed, and ffmpeg filters

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -228,7 +228,11 @@ impl Broker<'_> {
             );
             tq.per_shot_target_quality_routine(chunk, Some(worker_id)).unwrap();
 
-            if tq.probe_slow && chunk.tq_cq.is_some() {
+            if tq.probe_slow
+                && chunk.tq_cq.is_some()
+                && tq.probing_speed.is_none()
+                && self.project.args.ffmpeg_filter_args.is_empty()
+            {
                 let optimal_q = chunk.tq_cq.unwrap();
                 let extension = match self.project.args.encoder {
                     crate::encoder::Encoder::x264 => "264",

--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -230,6 +230,7 @@ impl Broker<'_> {
 
             if tq.probe_slow
                 && chunk.tq_cq.is_some()
+                && tq.probing_rate == 1
                 && tq.probing_speed.is_none()
                 && self.project.args.ffmpeg_filter_args.is_empty()
             {


### PR DESCRIPTION
Resolves #1021

During Target Quality, if the user specifies a `--probing-speed` with `--probe-slow`, the final probe is copied for the final encode chunk despite possibly being a different speed/preset than the one specified. Similarly, when the user specifies an FFmpeg filter parameter, the shortcut does not account for it as Target Quality probing does not use FFmpeg filters. This PR adds a check to ensure both of these values are unspecified.

Update: This PR now adds a check for the probing rate to ensure a value none other than `1` is used.