### PR TITLE
Remove clap from av1an-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,6 @@ dependencies = [
  "av-scenechange",
  "av1-grain",
  "cfg-if",
- "clap",
  "crossbeam-channel",
  "crossbeam-utils",
  "ctrlc",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -28,7 +28,6 @@ av1-grain = { version = "0.2.4", default-features = false, features = [
     "create",
 ] }
 cfg-if = "1.0.1"
-clap = { version = "4", features = ["derive"] }
 crossbeam-channel = "0.5.15"
 crossbeam-utils = "0.8.5"
 indicatif = "0.17.2"

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -24,7 +24,6 @@ use dashmap::DashMap;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, FromRepr, IntoStaticStr};
-pub use target_quality::VmafFeature;
 
 pub use crate::{
     concat::ConcatMethod,
@@ -479,6 +478,32 @@ pub enum ChunkOrdering {
     Sequential,
     #[strum(serialize = "random")]
     Random,
+}
+
+#[derive(
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    Serialize,
+    Deserialize,
+    Debug,
+    Display,
+    EnumString,
+    IntoStaticStr,
+    Hash,
+)]
+pub enum VmafFeature {
+    #[strum(serialize = "default")]
+    Default,
+    #[strum(serialize = "weighted")]
+    Weighted,
+    #[strum(serialize = "neg")]
+    Neg,
+    #[strum(serialize = "motionless")]
+    Motionless,
+    #[strum(serialize = "uhd")]
+    Uhd,
 }
 
 #[derive(

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -5,7 +5,6 @@ use std::{
     thread::available_parallelism,
 };
 
-use clap::ValueEnum;
 use ffmpeg::format::Pixel;
 use serde::{Deserialize, Serialize};
 use splines::{Interpolation, Key, Spline};
@@ -27,6 +26,7 @@ use crate::{
     ProbingStatistic,
     ProbingStatisticName,
     TargetMetric,
+    VmafFeature,
 };
 
 const SCORE_TOLERANCE: f64 = 0.01;
@@ -55,20 +55,6 @@ pub struct TargetQuality {
     pub probe_slow:            bool,
     pub probing_vmaf_features: Vec<VmafFeature>,
     pub probing_statistic:     ProbingStatistic,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum)]
-pub enum VmafFeature {
-    #[value(name = "default")]
-    Default,
-    #[value(name = "weighted")]
-    Weighted,
-    #[value(name = "neg")]
-    Neg,
-    #[value(name = "motionless")]
-    Motionless,
-    #[value(name = "uhd")]
-    Uhd,
 }
 
 impl TargetQuality {


### PR DESCRIPTION
An earlier PR added clap to av1an-core unnecessarily. This PR refactors the added Enum `VmafFeature` into `lib.rs` the same as other Enum options without the need for adding a CLI dependency to the core library.