### PR TITLE
Refactor scene handling code

### DIFF
--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -58,6 +58,7 @@ mod split;
 mod target_quality;
 mod util;
 pub mod vapoursynth;
+mod zones;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Input {

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -381,8 +381,7 @@ impl SceneFactory {
             |vs_script| Input::VapourSynth {
                 path:        vs_script.clone(),
                 vspipe_args: Vec::new(),
-                script_text: read_to_string(vs_script)
-                    .context("Failed to read VapourSynth script file")?,
+                script_text: read_to_string(vs_script).unwrap(),
             },
         );
 

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -381,7 +381,8 @@ impl SceneFactory {
             |vs_script| Input::VapourSynth {
                 path:        vs_script.clone(),
                 vspipe_args: Vec::new(),
-                script_text: read_to_string(vs_script).unwrap(),
+                script_text: read_to_string(vs_script)
+                    .context("Failed to read VapourSynth script file")?,
             },
         );
 

--- a/av1an-core/src/scenes/tests.rs
+++ b/av1an-core/src/scenes/tests.rs
@@ -1,4 +1,8 @@
-use crate::{context::Av1anContext, encoder::Encoder, scenes::Scene};
+use crate::{
+    context::Av1anContext,
+    encoder::Encoder,
+    scenes::{Scene, SceneFactory},
+};
 
 fn get_test_args() -> Av1anContext {
     use std::path::PathBuf;
@@ -80,6 +84,7 @@ fn get_test_args() -> Av1anContext {
         vs_scd_script: None,
         frames: 6900,
         args,
+        scene_factory: SceneFactory::new(),
     }
 }
 
@@ -87,7 +92,7 @@ fn get_test_args() -> Av1anContext {
 fn validate_zones_args() {
     let input = "45 729 aom --cq-level=20 --photon-noise 4 -x 60 --min-scene-len 12";
     let args = get_test_args();
-    let result = Scene::parse_from_zone(input, &args).unwrap();
+    let result = Scene::parse_from_zone(input, &args.args, args.frames).unwrap();
     assert_eq!(result.start_frame, 45);
     assert_eq!(result.end_frame, 729);
 
@@ -106,7 +111,7 @@ fn validate_zones_args() {
 fn validate_rav1e_zone_with_photon_noise() {
     let input = "45 729 rav1e reset --speed 6 --photon-noise 4";
     let args = get_test_args();
-    let result = Scene::parse_from_zone(input, &args).unwrap();
+    let result = Scene::parse_from_zone(input, &args.args, args.frames).unwrap();
     assert_eq!(result.start_frame, 45);
     assert_eq!(result.end_frame, 729);
 
@@ -123,7 +128,7 @@ fn validate_rav1e_zone_with_photon_noise() {
 fn validate_zones_reset() {
     let input = "729 1337 aom reset --cq-level=20 --cpu-used=5";
     let args = get_test_args();
-    let result = Scene::parse_from_zone(input, &args).unwrap();
+    let result = Scene::parse_from_zone(input, &args.args, args.frames).unwrap();
     assert_eq!(result.start_frame, 729);
     assert_eq!(result.end_frame, 1337);
 
@@ -146,7 +151,7 @@ fn validate_zones_reset() {
 fn validate_zones_encoder_changed() {
     let input = "729 1337 rav1e reset -s 3 -q 45";
     let args = get_test_args();
-    let result = Scene::parse_from_zone(input, &args).unwrap();
+    let result = Scene::parse_from_zone(input, &args.args, args.frames).unwrap();
     assert_eq!(result.start_frame, 729);
     assert_eq!(result.end_frame, 1337);
 
@@ -172,7 +177,7 @@ fn validate_zones_encoder_changed() {
 fn validate_zones_encoder_changed_no_reset() {
     let input = "729 1337 rav1e -s 3 -q 45";
     let args = get_test_args();
-    let result = Scene::parse_from_zone(input, &args);
+    let result = Scene::parse_from_zone(input, &args.args, args.frames);
     assert_eq!(
         result.err().unwrap().to_string(),
         "Zone includes encoder change but previous args were kept. You probably meant to specify \
@@ -184,7 +189,7 @@ fn validate_zones_encoder_changed_no_reset() {
 fn validate_zones_no_args() {
     let input = "2459 5000 rav1e";
     let args = get_test_args();
-    let result = Scene::parse_from_zone(input, &args);
+    let result = Scene::parse_from_zone(input, &args.args, args.frames);
     assert_eq!(
         result.err().unwrap().to_string(),
         "Zone includes encoder change but previous args were kept. You probably meant to specify \
@@ -196,7 +201,7 @@ fn validate_zones_no_args() {
 fn validate_zones_format_mismatch() {
     let input = "5000 -1 x264 reset";
     let args = get_test_args();
-    let result = Scene::parse_from_zone(input, &args);
+    let result = Scene::parse_from_zone(input, &args.args, args.frames);
     assert_eq!(
         result.err().unwrap().to_string(),
         "Zone specifies using x264, but this cannot be used in the same file as aom"
@@ -209,7 +214,7 @@ fn validate_zones_no_args_reset() {
     let args = get_test_args();
 
     // This is weird, but can technically work for some encoders so we'll allow it.
-    let result = Scene::parse_from_zone(input, &args).unwrap();
+    let result = Scene::parse_from_zone(input, &args.args, args.frames).unwrap();
     assert_eq!(result.start_frame, 5000);
     assert_eq!(result.end_frame, 6900);
 

--- a/av1an-core/src/split.rs
+++ b/av1an-core/src/split.rs
@@ -2,15 +2,10 @@
 mod tests;
 
 use std::{
-    fs::File,
-    io::{prelude::*, BufReader},
     path::Path,
     process::{Command, Stdio},
     string::ToString,
 };
-
-use anyhow::Context;
-use serde::{Deserialize, Serialize};
 
 use crate::scenes::Scene;
 
@@ -82,46 +77,4 @@ pub fn extra_splits(scenes: &[Scene], total_frames: usize, split_size: usize) ->
     }
 
     new_scenes
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-struct ScenesData {
-    scenes: Vec<Scene>,
-    frames: usize,
-}
-
-pub fn write_scenes_to_file(
-    scenes: &[Scene],
-    total_frames: usize,
-    scene_path: impl AsRef<Path>,
-) -> std::io::Result<()> {
-    // Writes a list of scenes and frame count to the file
-    let data = ScenesData {
-        scenes: scenes.to_vec(),
-        frames: total_frames,
-    };
-
-    // serializing the data should never fail, so unwrap is OK
-    let serialized = serde_json::to_string(&data).unwrap();
-
-    let mut file = File::create(scene_path)?;
-
-    file.write_all(serialized.as_bytes())?;
-
-    Ok(())
-}
-
-pub fn read_scenes_from_file(scene_path: &Path) -> anyhow::Result<(Vec<Scene>, usize)> {
-    let file = File::open(scene_path)?;
-
-    let reader = BufReader::new(file);
-
-    let data: ScenesData = serde_json::from_reader(reader).with_context(|| {
-        format!(
-            "Failed to parse scenes file {scene_path:?}, this likely means that the scenes file \
-             is corrupted"
-        )
-    })?;
-
-    Ok((data.scenes, data.frames))
 }

--- a/av1an-core/src/zones.rs
+++ b/av1an-core/src/zones.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, fs};
+use std::fs;
 
 use anyhow::bail;
 

--- a/av1an-core/src/zones.rs
+++ b/av1an-core/src/zones.rs
@@ -1,0 +1,24 @@
+use std::{collections::BTreeSet, fs};
+
+use anyhow::bail;
+
+use crate::{scenes::Scene, EncodeArgs};
+
+pub(crate) fn parse_zones(args: &EncodeArgs, frames: usize) -> anyhow::Result<Vec<Scene>> {
+    let mut zones = Vec::new();
+    if let Some(ref zones_file) = args.zones {
+        let input = fs::read_to_string(zones_file)?;
+        for zone_line in input.lines().map(str::trim).filter(|line| !line.is_empty()) {
+            zones.push(Scene::parse_from_zone(zone_line, args, frames)?);
+        }
+        zones.sort_unstable_by_key(|zone| zone.start_frame);
+        let mut segments = BTreeSet::new();
+        for zone in &zones {
+            if segments.contains(&zone.start_frame) {
+                bail!("Zones file contains overlapping zones");
+            }
+            segments.extend(zone.start_frame..zone.end_frame);
+        }
+    }
+    Ok(zones)
+}

--- a/av1an-core/src/zones.rs
+++ b/av1an-core/src/zones.rs
@@ -12,12 +12,12 @@ pub(crate) fn parse_zones(args: &EncodeArgs, frames: usize) -> anyhow::Result<Ve
             zones.push(Scene::parse_from_zone(zone_line, args, frames)?);
         }
         zones.sort_unstable_by_key(|zone| zone.start_frame);
-        let mut segments = BTreeSet::new();
-        for zone in &zones {
-            if segments.contains(&zone.start_frame) {
+        for i in 0..zones.len() - 1 {
+            let current_zone = &zones[i];
+            let next_zone = &zones[i + 1];
+            if current_zone.end_frame > next_zone.start_frame {
                 bail!("Zones file contains overlapping zones");
             }
-            segments.extend(zone.start_frame..zone.end_frame);
         }
     }
     Ok(zones)


### PR DESCRIPTION
This creates a struct responsible for managing and generating the scenes list, and splits it into two separate lists, one pre-extra-splits and one post-extra-splits. We will use the pre-extra-splits list in the future for target quality.