### PR TITLE
Fix loading of the scenes.json to load pre- and post- splits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           toolchain: nightly
           override: true
       - uses: Swatinem/rust-cache@v2
-      
+
       - name: Validate formatting
         run: |
           cargo fmt --all -- --check
@@ -70,7 +70,7 @@ jobs:
           cargo test --profile ci
 
   encode-tests:
-    needs: [ formatting, unit-tests ]
+    needs: [formatting, unit-tests]
     runs-on: ubuntu-latest
     container: shssoichiro/av1an-ci:latest
     steps:
@@ -296,10 +296,10 @@ jobs:
         run: |
           target/ci/av1an -i tt_sif.y4m --sc-only --sc-method fast -s "tt_sif_scenes.json"
           du -h tt_sif_scenes.json
-        continue-on-error: true
+          target/ci/av1an -i tt_sif.y4m -e aom --pix-format yuv420p -s "tt_sif_scenes.json"
 
   code-coverage:
-    needs: [ formatting, unit-tests, encode-tests ]
+    needs: [formatting, unit-tests, encode-tests]
     runs-on: ubuntu-latest
     container: shssoichiro/av1an-ci:latest
     steps:
@@ -338,7 +338,7 @@ jobs:
           fail_ci_if_error: false
 
   docker:
-    needs: [ formatting, unit-tests ]
+    needs: [formatting, unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -393,7 +393,7 @@ jobs:
           fi
 
   docker-publish:
-    needs: [ unit-tests, encode-tests, docker, publish-check ]
+    needs: [unit-tests, encode-tests, docker, publish-check]
     runs-on: ubuntu-latest
     if: needs.publish-check.outputs.should_publish == 'true'
     steps:

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -798,6 +798,7 @@ impl Av1anContext {
                 &zones,
             )?;
         }
+        self.frames = self.scene_factory.get_frame_count();
         self.scene_factory.write_scenes_to_file(scene_file)?;
         self.scene_factory.get_split_scenes()
     }

--- a/av1an-core/src/progress_bar.rs
+++ b/av1an-core/src/progress_bar.rs
@@ -290,6 +290,11 @@ pub fn update_progress_bar_estimates(
 ) {
     let completed_frames: usize =
         get_done().done.iter().map(|ref_multi| ref_multi.value().frames).sum();
+    if completed_frames == 0 {
+        // avoid division by 0
+        return;
+    }
+
     let total_size: u64 = get_done()
         .done
         .iter()


### PR DESCRIPTION
This change alters the format of the scenes.json file, which may cause resumes from prior versions of av1an to fail. Users should finish in-progress encodes before updating to this version.