### PR TITLE
Clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,15 +54,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +234,8 @@ dependencies = [
  "path_abs",
  "shlex",
  "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "vergen-git2",
 ]
 
@@ -251,7 +244,6 @@ name = "av1an-core"
 version = "0.4.4"
 dependencies = [
  "affinity",
- "ansi_term",
  "anyhow",
  "arrayvec",
  "av-decoders",
@@ -260,6 +252,7 @@ dependencies = [
  "av-scenechange",
  "av1-grain",
  "cfg-if",
+ "colored",
  "crossbeam-channel",
  "crossbeam-utils",
  "ctrlc",
@@ -289,8 +282,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "tracing-appender",
- "tracing-subscriber",
  "vapoursynth",
  "which",
  "y4m",
@@ -494,6 +485,15 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "console"
@@ -1005,7 +1005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1781,12 +1781,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,16 @@
 members = ["av1an-core", "av1an"]
 resolver = "2"
 
+[workspace.dependencies]
+anyhow = "1.0.42"
+ffmpeg = { version = "3.0.2", package = "ffmpeg-the-third", features = [
+    "serialize",
+] }
+num-traits = "0.2.19"
+once_cell = "1.8.0"
+path_abs = "0.5.1"
+tracing = "0.1"
+
 [profile.dev.package.av-scenechange]
 opt-level = 3
 

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -16,7 +16,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.42"
+anyhow = { workspace = true }
 arrayvec = "0.7.2"
 av-decoders = { version = "0.2.0", features = ["ffmpeg", "vapoursynth"] }
 av-format = "0.7.0"
@@ -31,62 +31,52 @@ av1-grain = { version = "0.2.4", default-features = false, features = [
 cfg-if = "1.0.1"
 crossbeam-channel = "0.5.15"
 crossbeam-utils = "0.8.5"
+dashmap = { version = "6.0.0", features = ["serde"] }
+ffmpeg = { workspace = true }
 indicatif = "0.17.12"
 itertools = "0.14.0"
 memchr = "2.7.5"
 nom = "7.1.1"
-num-traits = "0.2.19"
-once_cell = "1.8.0"
+num-traits = { workspace = true }
+once_cell = { workspace = true }
 parking_lot = "0.12.4"
 pastey = "0.1.0"
-path_abs = "0.5.1"
+path_abs = { workspace = true }
+plotters = { version = "0.3.1", default-features = false, features = [
+    "svg_backend",
+    "line_series",
+] }
 rand = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simdutf8 = "0.1.3"
+smallvec = { version = "1.15.1", default-features = false, features = [
+    "const_generics",
+    "const_new",
+    "union",
+] }
 strsim = "0.11.0"
 strum = { version = "0.27.1", features = ["derive"] }
 sysinfo = "0.35.2"
 textwrap = "0.16.0"
 thiserror = "2.0.11"
+tracing = { workspace = true }
 which = "8.0.0"
 y4m = "0.8.0"
+vapoursynth = { version = "0.4.0", features = [
+    "vsscript-functions",
+    "vapoursynth-functions",
+] }
 # TODO: move all of this CLI stuff to av1an-cli
-ansi_term = "0.12.1"
+colored = "3.0.0"
 ctrlc = "3.4.7"
 regex = "1.11.1"
 tokio = { version = "1.45", features = ["full"] }
-tracing = "0.1"
-tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # TODO: https://github.com/elast0ny/affinity/issues/2
 # update this when macos support is implemented
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
 affinity = "0.1.2"
-
-[dependencies.smallvec]
-version = "1.15.1"
-default-features = false
-features = ["const_generics", "const_new", "union"]
-
-[dependencies.ffmpeg]
-package = "ffmpeg-the-third"
-version = "3.0.2"
-features = ["serialize"]
-
-[dependencies.plotters]
-version = "0.3.1"
-default-features = false
-features = ["svg_backend", "line_series"]
-
-[dependencies.vapoursynth]
-version = "0.4.0"
-features = ["vsscript-functions", "vapoursynth-functions"]
-
-[dependencies.dashmap]
-version = "6.0.0"
-features = ["serde"]
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -16,9 +16,9 @@ use std::{
     thread::{self, available_parallelism},
 };
 
-use ansi_term::{Color, Style};
 use anyhow::Context;
 use av1_grain::TransferFunction;
+use colored::*;
 use itertools::Itertools;
 use num_traits::cast::ToPrimitive;
 use rand::{prelude::SliceRandom, rng};
@@ -303,20 +303,20 @@ impl Av1anContext {
 
             info!(
                 "\n{}{} {} {}{} {} {}{} {} {}{} {}\n{}: {}",
-                Color::Green.bold().paint("Q"),
-                Color::Green.paint("ueue"),
-                Color::Green.bold().paint(format!("{len}", len = chunk_queue.len())),
-                Color::Blue.bold().paint("W"),
-                Color::Blue.paint("orkers"),
-                Color::Blue.bold().paint(format!("{workers}", workers = self.args.workers)),
-                Color::Purple.bold().paint("E"),
-                Color::Purple.paint("ncoder"),
-                Color::Purple.bold().paint(format!("{encoder}", encoder = self.args.encoder)),
-                Color::Purple.bold().paint("P"),
-                Color::Purple.paint("asses"),
-                Color::Purple.bold().paint(format!("{passes}", passes = self.args.passes)),
-                Style::default().bold().paint("Params"),
-                Style::default().dimmed().paint(self.args.video_params.join(" "))
+                "Q".green().bold(),
+                "ueue".green(),
+                format!("{len}", len = chunk_queue.len()).green().bold(),
+                "W".blue().bold(),
+                "orkers".blue(),
+                format!("{workers}", workers = self.args.workers).blue().bold(),
+                "E".purple().bold(),
+                "ncoder".purple(),
+                format!("{encoder}", encoder = self.args.encoder).purple().bold(),
+                "P".purple().bold(),
+                "asses".purple(),
+                format!("{passes}", passes = self.args.passes).purple().bold(),
+                "Params".bold(),
+                self.args.video_params.join(" ").dimmed()
             );
 
             if self.args.verbosity == Verbosity::Normal {

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -26,7 +26,6 @@ pub use crate::{
     concat::ConcatMethod,
     context::Av1anContext,
     encoder::Encoder,
-    logging::{init_logging, DEFAULT_LOG_LEVEL},
     settings::{EncodeArgs, InputPixelFormat, PixelFormat},
     target_quality::TargetQuality,
     util::read_in_dir,
@@ -39,7 +38,6 @@ mod concat;
 mod context;
 mod encoder;
 pub mod ffmpeg;
-mod logging;
 mod metrics {
     pub mod butteraugli;
     pub mod statistics;

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -4,10 +4,10 @@ use std::{
     thread,
 };
 
-use ansi_term::Style;
 use anyhow::bail;
 use av_decoders::{DecoderImpl, FfmpegDecoder, VapoursynthDecoder, Y4mDecoder};
 use av_scenechange::{detect_scene_changes, Decoder, DetectionOptions, SceneDetectionSpeed};
+use colored::*;
 use ffmpeg::format::Pixel;
 use itertools::Itertools;
 use smallvec::{smallvec, SmallVec};
@@ -38,7 +38,7 @@ pub fn av_scenechange_detect(
 ) -> anyhow::Result<(Vec<Scene>, usize)> {
     if verbosity != Verbosity::Quiet {
         if std::io::stderr().is_terminal() {
-            eprintln!("{}", Style::default().bold().paint("Scene detection"));
+            eprintln!("{}", "Scene detection".bold());
         } else {
             eprintln!("Scene detection");
         }

--- a/av1an-core/src/scenes/tests.rs
+++ b/av1an-core/src/scenes/tests.rs
@@ -12,7 +12,6 @@ fn get_test_args() -> Av1anContext {
     use crate::{
         concat::ConcatMethod,
         into_vec,
-        logging::DEFAULT_LOG_LEVEL,
         settings::{EncodeArgs, InputPixelFormat, PixelFormat},
         ChunkMethod,
         ChunkOrdering,
@@ -23,8 +22,6 @@ fn get_test_args() -> Av1anContext {
     };
 
     let args = EncodeArgs {
-        log_file:              PathBuf::new(),
-        log_level:             DEFAULT_LOG_LEVEL,
         ffmpeg_filter_args:    Vec::new(),
         temp:                  String::new(),
         force:                 false,

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -11,7 +11,6 @@ use ffmpeg::format::Pixel;
 use itertools::{chain, Itertools};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
-use tracing_subscriber::filter::LevelFilter;
 
 use crate::{
     concat::ConcatMethod,
@@ -92,8 +91,6 @@ pub struct EncodeArgs {
     pub output_pix_format:  PixelFormat,
 
     pub verbosity:   Verbosity,
-    pub log_file:    PathBuf,
-    pub log_level:   LevelFilter,
     pub resume:      bool,
     pub keep:        bool,
     pub force:       bool,

--- a/av1an/Cargo.toml
+++ b/av1an/Cargo.toml
@@ -18,23 +18,20 @@ name = "av1an"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1.0.42"
+anyhow = { workspace = true }
 av1an-core = { path = "../av1an-core", version = "0.4.1" }
 clap = { version = "4.5.40", features = ["derive"] }
-num-traits = "0.2.19"
-once_cell = "1.8.0"
-path_abs = "0.5.1"
+ffmpeg = { workspace = true }
+num-traits = { workspace = true }
+once_cell = { workspace = true }
+path_abs = { workspace = true }
 shlex = "1.3.0"
-tracing = "0.1"
+tracing = { workspace = true }
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-[build-dependencies.vergen-git2]
-version = "1.0.0"
-features = ["build", "rustc", "cargo"]
-
-[dependencies.ffmpeg]
-package = "ffmpeg-the-third"
-version = "3.0.2"
-features = ["serialize"]
+[build-dependencies]
+vergen-git2 = { version = "1.0.0", features = ["build", "rustc", "cargo"] }
 
 [features]
 default = []


### PR DESCRIPTION
- Organize all dependencies together in ABC order where possible
- Use workspace `Cargo.toml` for deps which are shared between library and CLI
- Move logging from library to CLI
- Migrate from 6-years-unmaintained `ansi_term` crate to more modern `colored` crate