### PR TITLE
replace TQ tolerance with configurable ranges

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -221,9 +221,10 @@ impl Broker<'_> {
             update_mp_msg(
                 worker_id,
                 format!(
-                    "Targeting {metric} Quality: {target}",
+                    "Targeting {metric} Quality: {min}-{max}",
                     metric = tq.metric,
-                    target = tq.target
+                    min = tq.target.0,
+                    max = tq.target.1
                 ),
             );
             for r#try in 1..=self.project.args.max_tries {

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -301,8 +301,6 @@ impl EncodeArgs {
                 warn!("Target quality with less than 4 probes is experimental and not recommended");
             }
 
-            ensure!(target_quality.min_q >= 1);
-
             if let Some(resolution) = &target_quality.probe_res {
                 match resolution.split('x').collect::<Vec<&str>>().as_slice() {
                     [width_str, height_str] => {

--- a/site/src/Features/TargetQuality.md
+++ b/site/src/Features/TargetQuality.md
@@ -67,9 +67,7 @@ Alternatively:
 
 - [`--target-metric TargetMetric`](../Cli/target_quality.md#target-metric---target-metric) - Chooses the metric used to evaluate quality of each segment
 
-- [`--target-quality FLOAT`](../Cli/target_quality.md#target-quality---target-quality) - enables target quality with default settings for that encoder, targets FLOAT value
-
-- [`--min_q INT`](../Cli/target_quality.md#minimum-quantizer---min-q), [`--max_q INT`](../Cli/target_quality.md#maximum-quantizer---max-q) - Overrides default CRF/CQ boundaries for search
+- [`--target-quality FLOAT-FLOAT`](../Cli/target_quality.md#target-quality---target-quality) - enables target quality with default settings for that encoder, targets a range with FLOAT values
 
 - [`--probes INT`](../Cli/target_quality.md#probes---probes) - Overrides maximum amount of probes to make for each segment (Default 4)
 


### PR DESCRIPTION
Hammer the moldy chains that the developers shackled on the users. Put an end to the suffocating tyranny and give the users the long-awaited freedom.

Shatter the rigid constraints that imprisoned creative workflows in a cage of arbitrary limitations. Break free from the oppressive single-value targeting that forced users into narrow, inflexible quality corridors. Demolish the ancient walls of hardcoded tolerances that stood between encoders and their rightful control over quality ranges. Unleash the powerful flexibility that users have desperately craved, replacing the stale dictatorship of fixed thresholds with the sweet liberation of configurable boundaries.

- Replace fixed 1% tolerance with user-configurable target quality ranges
- Change `--target-quality` from single value to range format (`75-85` or `1.0-1.5`). Single values will continue working.
- Add `--qp-range` parameter to constrain quantizer search bounds independently. This makes it name more expressive/intuitive since `--min_q` can be mistaken with "quality". This will also make it similar to TQ range and it will help us remove a parameter/flag completely.
- Maintain backward compatibility by auto-generating range for single target values.