### PR TITLE
Refactor to reduce number of spawned Environments

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -228,7 +228,11 @@ impl Broker<'_> {
                 ),
             );
             for r#try in 1..=self.project.args.max_tries {
-                let res = tq.per_shot_target_quality_routine(chunk, Some(worker_id));
+                let res = tq.per_shot_target_quality_routine(
+                    chunk,
+                    Some(worker_id),
+                    self.project.args.vapoursynth_plugins.as_ref(),
+                );
                 if let Err(e) = res {
                     if r#try >= self.project.args.max_tries {
                         error!(

--- a/av1an-core/src/chunk.rs
+++ b/av1an-core/src/chunk.rs
@@ -60,7 +60,8 @@ impl Chunk {
             let grain_table = Path::new(&self.temp).join(format!("iso{iso_setting}-grain.tbl"));
             if !grain_table.exists() {
                 debug!("Generating grain table at ISO {iso_setting}");
-                let (mut width, mut height) = self.input.resolution()?;
+                let clip_info = self.input.clip_info(None)?;
+                let (mut width, mut height) = clip_info.resolution;
                 if self.noise_size.0.is_some() {
                     width = self.noise_size.0.unwrap();
                 }
@@ -68,7 +69,7 @@ impl Chunk {
                     height = self.noise_size.1.unwrap();
                 }
                 let transfer_function =
-                    self.input.transfer_function_params_adjusted(&self.video_params)?;
+                    clip_info.transfer_function_params_adjusted(&self.video_params);
                 let params = generate_photon_noise_params(0, u64::MAX, NoiseGenArgs {
                     iso_setting,
                     width,

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -869,7 +869,11 @@ impl Av1anContext {
             self.args.chroma_noise,
         )?;
         if let Some(ref tq) = self.args.target_quality {
-            tq.per_shot_target_quality_routine(&mut chunk, None)?;
+            tq.per_shot_target_quality_routine(
+                &mut chunk,
+                None,
+                self.args.vapoursynth_plugins.as_ref(),
+            )?;
         }
         Ok(chunk)
     }

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -34,7 +34,7 @@ use crate::{
     concat::{self, ConcatMethod},
     create_dir,
     determine_workers,
-    ffmpeg::{compose_ffmpeg_pipe, num_frames},
+    ffmpeg::{compose_ffmpeg_pipe, get_num_frames},
     get_done,
     init_done,
     into_vec,
@@ -156,7 +156,7 @@ impl Av1anContext {
 
             // frames need to be recalculated in this case
             if self.frames == 0 {
-                self.frames = self.args.input.frames(self.vs_script.clone())?;
+                self.frames = self.args.input.clip_info(self.vs_script.clone())?.num_frames;
                 done.frames.store(self.frames, atomic::Ordering::Relaxed);
             }
 
@@ -221,17 +221,25 @@ impl Av1anContext {
           None
         };
 
-        let res = self.args.input.resolution()?;
-        let fps_ratio = self.args.input.frame_rate()?;
+        let clip_info = self.args.input.clip_info(None)?;
+        let res = clip_info.resolution;
+        let fps_ratio = clip_info.frame_rate;
         let fps = fps_ratio.to_f64().unwrap();
-        let format = self.args.input.pixel_format()?;
-        let tfc = self.args.input.transfer_function_params_adjusted(&self.args.video_params)?;
+        let format = clip_info.format_info;
+        let tfc = clip_info.transfer_function_params_adjusted(&self.args.video_params);
         info!(
             "Input: {}x{} @ {:.3} fps, {}, {}",
             res.0,
             res.1,
             fps,
-            format,
+            match format {
+                InputPixelFormat::VapourSynth {
+                    bit_depth,
+                } => format!("{bit_depth} BPC"),
+                InputPixelFormat::FFmpeg {
+                    format,
+                } => format!("{format:?}"),
+            },
             match tfc {
                 TransferFunction::SMPTE2084 => "HDR",
                 TransferFunction::BT1886 => "SDR",
@@ -297,7 +305,7 @@ impl Av1anContext {
             };
 
             if self.args.workers == 0 {
-                self.args.workers = determine_workers(&self.args) as usize;
+                self.args.workers = determine_workers(&self.args)? as usize;
             }
             self.args.workers = cmp::min(self.args.workers, chunk_queue.len());
 
@@ -412,7 +420,7 @@ impl Av1anContext {
             if self.args.vmaf || self.args.target_quality.is_some() {
                 let vmaf_res = if let Some(ref tq) = self.args.target_quality {
                     if tq.vmaf_res == "inputres" {
-                        let inputres = self.args.input.resolution()?;
+                        let inputres = self.args.input.clip_info(None)?.resolution;
                         format!("{width}x{height}", width = inputres.0, height = inputres.1)
                     } else {
                         tq.vmaf_res.clone()
@@ -704,7 +712,7 @@ impl Av1anContext {
         }
 
         if current_pass == chunk.passes {
-            let encoded_frames = num_frames(chunk.output().as_ref());
+            let encoded_frames = get_num_frames(chunk.output().as_ref());
 
             let err_str = match encoded_frames {
                 Ok(encoded_frames)
@@ -942,7 +950,7 @@ impl Av1anContext {
     }
 
     fn create_video_queue_vs(&self, scenes: &[Scene], vs_script: &Path) -> Vec<Chunk> {
-        let frame_rate = self.args.input.frame_rate().unwrap().to_f64().unwrap();
+        let frame_rate = self.args.input.clip_info(None).unwrap().frame_rate.to_f64().unwrap();
         let chunk_queue: Vec<Chunk> = scenes
             .iter()
             .enumerate()
@@ -956,7 +964,7 @@ impl Av1anContext {
 
     fn create_video_queue_select(&self, scenes: &[Scene]) -> Vec<Chunk> {
         let input = self.args.input.as_video_path();
-        let frame_rate = self.args.input.frame_rate().unwrap().to_f64().unwrap();
+        let frame_rate = self.args.input.clip_info(None).unwrap().frame_rate.to_f64().unwrap();
 
         let chunk_queue: Vec<Chunk> = scenes
             .iter()
@@ -979,7 +987,7 @@ impl Av1anContext {
 
     fn create_video_queue_segment(&self, scenes: &[Scene]) -> anyhow::Result<Vec<Chunk>> {
         let input = self.args.input.as_video_path();
-        let frame_rate = self.args.input.frame_rate().unwrap().to_f64().unwrap();
+        let frame_rate = self.args.input.clip_info(None)?.frame_rate.to_f64().unwrap();
 
         debug!("Splitting video");
         segment(
@@ -1016,7 +1024,7 @@ impl Av1anContext {
 
     fn create_video_queue_hybrid(&self, scenes: &[Scene]) -> anyhow::Result<Vec<Chunk>> {
         let input = self.args.input.as_video_path();
-        let frame_rate = self.args.input.frame_rate().unwrap().to_f64().unwrap();
+        let frame_rate = self.args.input.clip_info(None)?.frame_rate.to_f64().unwrap();
 
         let keyframes = crate::ffmpeg::get_keyframes(input).unwrap();
 
@@ -1092,7 +1100,7 @@ impl Av1anContext {
 
         let output_ext = self.args.encoder.output_extension();
 
-        let num_frames = num_frames(Path::new(file))?;
+        let num_frames = get_num_frames(Path::new(file))?;
 
         let mut chunk = Chunk {
             temp: self.args.temp.clone(),

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -376,7 +376,7 @@ impl SceneFactory {
         // We should only be calling this when scenes haven't been created yet
         debug_assert!(self.data.scenes.is_none());
 
-        let frames = args.input.frames(vs_script.clone())?;
+        let frames = args.input.clip_info(vs_script.clone())?.num_frames;
 
         // Create a new input with the generated VapourSynth script for Scene Detection
         let input = vs_scd_script.as_ref().map_or_else(
@@ -426,7 +426,7 @@ impl SceneFactory {
                         zone_overrides: None,
                     });
                 }
-                (scenes, args.input.frames(vs_script.clone())?)
+                (scenes, frames)
             },
         };
 

--- a/av1an-core/src/scenes/tests.rs
+++ b/av1an-core/src/scenes/tests.rs
@@ -75,6 +75,7 @@ fn get_test_args() -> Av1anContext {
         vmaf_threads:          None,
         vmaf_filter:           None,
         probe_res:             None,
+        vapoursynth_plugins:   None,
     };
     Av1anContext {
         vs_script: None,

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -40,6 +40,32 @@ pub enum InputPixelFormat {
     FFmpeg { format: Pixel },
 }
 
+impl InputPixelFormat {
+    #[inline]
+    pub fn as_bit_depth(&self) -> anyhow::Result<usize> {
+        match self {
+            InputPixelFormat::VapourSynth {
+                bit_depth,
+            } => Ok(*bit_depth),
+            InputPixelFormat::FFmpeg {
+                ..
+            } => Err(anyhow::anyhow!("failed to get bit depth; wrong input type")),
+        }
+    }
+
+    #[inline]
+    pub fn as_pixel_format(&self) -> anyhow::Result<Pixel> {
+        match self {
+            InputPixelFormat::VapourSynth {
+                ..
+            } => Err(anyhow::anyhow!("failed to get bit depth; wrong input type")),
+            InputPixelFormat::FFmpeg {
+                format,
+            } => Ok(*format),
+        }
+    }
+}
+
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct EncodeArgs {


### PR DESCRIPTION
- Use one single Environment to get plugin info
- Avoid global state for plugins
- Initialize once at start of app
- Only instantiate one VS Environment or ffmpeg Input to get all clip info
- Cache clip info