### PR TITLE
Add --completions flag to generate shell completions at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "anyhow",
  "av1an-core",
  "clap",
+ "clap_complete",
  "ffmpeg-the-third",
  "num-traits",
  "once_cell",
@@ -460,6 +461,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/av1an/Cargo.toml
+++ b/av1an/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 av1an-core = { path = "../av1an-core", version = "0.4.1" }
 clap = { version = "4.5.40", features = ["derive"] }
+clap_complete = "4.5.54"
 ffmpeg = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -34,7 +34,8 @@ use av1an_core::{
     Verbosity,
     VmafFeature,
 };
-use clap::{value_parser, Parser};
+use clap::{value_parser, CommandFactory, Parser};
+use clap_complete::generate;
 use num_traits::cast::ToPrimitive;
 use once_cell::sync::OnceCell;
 use path_abs::{PathAbs, PathInfo};
@@ -222,6 +223,10 @@ pub struct CliOpts {
     #[clap(long, default_value_t = DEFAULT_LOG_LEVEL, ignore_case = true)]
     // "off" is also an allowed value for LevelFilter but we just disable the user from setting it
     pub log_level: LevelFilter,
+
+    /// Generate shell completions for the specified shell and exit
+    #[clap(long, conflicts_with = "input", value_name = "SHELL")]
+    pub completions: Option<clap_complete::Shell>,
 
     /// Resume previous session from temporary directory
     #[clap(short, long)]
@@ -1228,6 +1233,13 @@ pub fn run() -> anyhow::Result<()> {
     let cli_options = CliOpts::parse();
     let log_file = cli_options.log_file.as_ref().map(PathBuf::from);
     let log_level = cli_options.log_level;
+
+    let completions = cli_options.completions;
+    if let Some(shell) = completions {
+        generate(shell, &mut CliOpts::command(), "av1an", &mut io::stdout());
+        return Ok(());
+    }
+
     let args = parse_cli(cli_options)?;
     let first_arg = args.first().unwrap();
 
@@ -1240,6 +1252,8 @@ pub fn run() -> anyhow::Result<()> {
         log_file,
         log_level,
     )?;
+
+
 
     for arg in args {
         Av1anContext::new(arg)?.encode_file()?;

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -1231,8 +1231,6 @@ pub fn parse_cli(args: CliOpts) -> anyhow::Result<Vec<EncodeArgs>> {
 #[instrument]
 pub fn run() -> anyhow::Result<()> {
     let cli_options = CliOpts::parse();
-    let log_file = cli_options.log_file.as_ref().map(PathBuf::from);
-    let log_level = cli_options.log_level;
 
     let completions = cli_options.completions;
     if let Some(shell) = completions {
@@ -1240,6 +1238,8 @@ pub fn run() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let log_file = cli_options.log_file.as_ref().map(PathBuf::from);
+    let log_level = cli_options.log_level;
     let args = parse_cli(cli_options)?;
     let first_arg = args.first().unwrap();
 
@@ -1252,8 +1252,6 @@ pub fn run() -> anyhow::Result<()> {
         log_file,
         log_level,
     )?;
-
-
 
     for arg in args {
         Av1anContext::new(arg)?.encode_file()?;


### PR DESCRIPTION
This PR adds a `--completions` flag. Invoking av1an with this flag prints completions for the specified shell to stdout.