### PR TITLE
Fix zones replaces last frame with 0 and fails to parse

### DIFF
--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -82,7 +82,7 @@ impl Av1anContext {
         args.validate()?;
 
         let mut this = Self {
-            frames: 0,
+            frames: args.input.clip_info(None)?.num_frames,
             vs_script: None,
             vs_scd_script: None,
             args,


### PR DESCRIPTION
Resolves #1056

The `Av1anContext` object stores the number of frames in the input. Currently it evaluates to 0, the initial value, and is not updated before zones are parsed. It should be removed and replaced with `args.input.clip_info()?.num_frames` instead.

Now that `clip_info` is retrieved and cached during validation, we can intialize the `Av1anContext` object with `args.input.clip_info()?.num_frames` instead of 0. When zones are parsed, the `Av1anContext.frames` value will be correct and `0` won't be used in place of the last frame in zones.

However, `clip_info` currently uses FFmpeg (used to cache the initial clip_info values) and it may disagree with the chosen VapourSynth chunking method and result in a frame mismatch:

```ps
> av1an.exe -i long.mkv --verbose --chunk-method dgdecnv --zones zones.txt
 INFO encode_file: Indexing input with DGDecNV
 INFO encode_file: Input: 1920x1080 @ 23.976 fps, YUV420P10LE, SDR
Scene detection
00:01:10 ▐██████████████████████████████████████████████████████████████████████████▌ 100% 2212/2212 (31.33 fps, eta 0s)Error: Scene change: Expected 1955 frames but saw 1954. This may indicate an issue with the input or filters.
```

PR #1030 should prevent this as the clip_info is initialized and cached using the appropriate method so the info is consistent. I recommend waiting for that PR and then updating this to remove the `None` parameter from `clip_info()`. Or just remember to remove the `None` when merging that PR - whichever is easier.

Ideally, we should phase out storing the frames in `Av1anContext` and simply use `clip_info()` everywhere.

Thanks,
\- Boats M.