### PR TITLE
Remove dependency on the ffmpeg library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3778ec4ac567969eaafbb556bb43a0a34ed21afc51a3c1ec1e467cf727a7dfc"
 dependencies = [
- "ffmpeg-the-third",
  "num-rational",
  "thiserror 2.0.12",
  "v_frame",
@@ -229,7 +228,6 @@ dependencies = [
  "av1an-core",
  "clap",
  "clap_complete",
- "ffmpeg-the-third",
  "num-traits",
  "once_cell",
  "path_abs",
@@ -258,9 +256,8 @@ dependencies = [
  "crossbeam-utils",
  "ctrlc",
  "dashmap",
- "ffmpeg-the-third",
  "indicatif",
- "itertools 0.14.0",
+ "itertools",
  "memchr",
  "nom",
  "num-traits",
@@ -304,26 +301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,9 +311,6 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -400,15 +374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,27 +384,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "clang"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c044c781163c001b913cd018fc95a628c50d0d2dfea8bca77dad71edb16e37"
-dependencies = [
- "clang-sys",
- "libc",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
 
 [[package]]
 name = "clap"
@@ -707,32 +651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "ffmpeg-sys-the-third"
-version = "3.0.1+ffmpeg-7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c9ca95182de7f6be018b8ceb6a1c4bc5b733386d4afc6ae619ea88abf7492e"
-dependencies = [
- "bindgen",
- "cc",
- "clang",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "ffmpeg-the-third"
-version = "3.0.2+ffmpeg-7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a64b051fb2a1ea7422cac21153e2852b3ed1142c9ffa5fac7b3194074611cd3"
-dependencies = [
- "bitflags 2.9.1",
- "ffmpeg-sys-the-third",
- "libc",
- "serde",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,12 +695,6 @@ dependencies = [
  "log",
  "url",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -947,15 +859,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -996,12 +899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,16 +914,6 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
-dependencies = [
- "cfg-if",
- "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1514,12 +1401,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,6 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1.0.42"
-ffmpeg = { version = "3.0.2", package = "ffmpeg-the-third", features = [
-    "serialize",
-] }
 num-traits = "0.2.19"
 once_cell = "1.8.0"
 path_abs = "0.5.1"

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -18,11 +18,10 @@ readme = "../README.md"
 [dependencies]
 anyhow = { workspace = true }
 arrayvec = "0.7.2"
-av-decoders = { version = "0.3.0", features = ["ffmpeg", "vapoursynth"] }
+av-decoders = { version = "0.3.0", features = ["vapoursynth"] }
 av-format = "0.7.0"
 av-ivf = "0.5.0"
 av-scenechange = { version = "0.17.2", default-features = false, features = [
-    "ffmpeg",
     "vapoursynth",
 ] }
 av1-grain = { version = "0.2.4", default-features = false, features = [
@@ -32,7 +31,6 @@ cfg-if = "1.0.1"
 crossbeam-channel = "0.5.15"
 crossbeam-utils = "0.8.5"
 dashmap = { version = "6.0.0", features = ["serde"] }
-ffmpeg = { workspace = true }
 indicatif = "0.18.0"
 itertools = "0.14.0"
 memchr = "2.7.5"
@@ -83,12 +81,6 @@ tempfile = "3.20.0"
 
 [features]
 default = ["vapoursynth_new_api"]
-ffmpeg_static = [
-    "ffmpeg/static",
-    "ffmpeg/build",
-    "av-decoders/ffmpeg_build",
-    "av-decoders/ffmpeg_static",
-]
 vapoursynth_new_api = [
     "vapoursynth/vapoursynth-api-32",
     "vapoursynth/vsscript-api-31",

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -322,7 +322,8 @@ impl Av1anContext {
                 let temp = self.args.temp.as_str();
                 let audio_params = self.args.audio_params.as_slice();
                 Some(s.spawn(move |_| {
-                    let audio_output = crate::ffmpeg::encode_audio(input, temp, audio_params);
+                    let audio_output =
+                        crate::ffmpeg::encode_audio(input, temp, audio_params).unwrap();
                     get_done().audio_done.store(true, atomic::Ordering::SeqCst);
 
                     let progress_file = Path::new(temp).join("done.json");

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -96,9 +96,6 @@ impl Av1anContext {
     /// Initialize logging routines and create temporary directories
     #[tracing::instrument(level = "debug")]
     fn initialize(&mut self) -> anyhow::Result<()> {
-        ffmpeg::init()?;
-        ffmpeg::util::log::set_level(ffmpeg::util::log::level::Level::Fatal);
-
         if !self.args.resume && Path::new(&self.args.temp).is_dir() {
             fs::remove_dir_all(&self.args.temp).with_context(|| {
                 format!(
@@ -879,7 +876,7 @@ impl Av1anContext {
                 end = end_frame - 1
             ),
             "-pix_fmt",
-            self.args.output_pix_format.format.descriptor().unwrap().name(),
+            self.args.output_pix_format.format.to_pix_fmt_string(),
             "-strict",
             "-1",
             "-f",
@@ -1173,7 +1170,7 @@ impl Av1anContext {
             "-strict",
             "-1",
             "-pix_fmt",
-            self.args.output_pix_format.format.descriptor().unwrap().name(),
+            self.args.output_pix_format.format.to_pix_fmt_string(),
             "-f",
             "yuv4mpegpipe",
             "-",

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -167,7 +167,7 @@ pub fn get_keyframes(source: &Path) -> anyhow::Result<Vec<usize>> {
         .arg("-show_frames")
         .arg("-select_streams")
         .arg("v:0")
-        .arg("show_entries")
+        .arg("-show_entries")
         .arg("frame=key_frame")
         .arg(source)
         .output()?

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -104,7 +104,7 @@ pub fn get_num_frames(source: &Path) -> anyhow::Result<usize> {
         .arg(source)
         .output()?
         .stdout;
-    match String::from_utf8_lossy(&output).parse::<usize>() {
+    match String::from_utf8_lossy(&output).trim().parse::<usize>() {
         Ok(x) if x > 0 => Ok(x),
         _ => {
             // If we got empty output or a 0 frame count, try using the slower
@@ -129,7 +129,7 @@ fn get_num_frames_slow(source: &Path) -> anyhow::Result<usize> {
         .arg(source)
         .output()?
         .stdout;
-    Ok(String::from_utf8_lossy(&output).parse::<usize>()?)
+    Ok(String::from_utf8_lossy(&output).trim().parse::<usize>()?)
 }
 
 fn parse_frame_rate(rate: &str) -> anyhow::Result<Rational64> {

--- a/av1an-core/src/ffmpeg.rs
+++ b/av1an-core/src/ffmpeg.rs
@@ -2,17 +2,13 @@ use std::{
     ffi::OsStr,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    str::FromStr,
 };
 
+use anyhow::bail;
 use av_format::rational::Rational64;
-use ffmpeg::{
-    color::TransferCharacteristic,
-    format::{context::Input, input, Pixel},
-    media::Type as MediaType,
-    Error::StreamNotFound,
-    Stream,
-};
 use path_abs::{PathAbs, PathInfo};
+use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::{into_array, into_vec, ClipInfo, InputPixelFormat};
@@ -20,7 +16,7 @@ use crate::{into_array, into_vec, ClipInfo, InputPixelFormat};
 #[inline]
 pub fn compose_ffmpeg_pipe<S: Into<String>>(
     params: impl IntoIterator<Item = S>,
-    pix_format: Pixel,
+    pix_format: FFPixelFormat,
 ) -> Vec<String> {
     let mut p: Vec<String> =
         into_vec!["ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", "-",];
@@ -29,7 +25,7 @@ pub fn compose_ffmpeg_pipe<S: Into<String>>(
 
     p.extend(into_array![
         "-pix_fmt",
-        pix_format.descriptor().unwrap().name(),
+        pix_format.to_pix_fmt_string(),
         "-strict",
         "-1",
         "-f",
@@ -40,105 +36,167 @@ pub fn compose_ffmpeg_pipe<S: Into<String>>(
     p
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct FfProbeInfo {
+    pub streams: Vec<FfProbeStreamInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FfProbeStreamInfo {
+    pub width:          u32,
+    pub height:         u32,
+    pub pix_fmt:        String,
+    pub color_transfer: Option<String>,
+    pub avg_frame_rate: String,
+    pub nb_frames:      Option<usize>,
+}
+
 #[inline]
-pub fn get_clip_info(source: &Path) -> Result<ClipInfo, ffmpeg::Error> {
-    let mut ictx = input(source)?;
-    let input = ictx.streams().best(MediaType::Video).ok_or(StreamNotFound)?;
-    let video_stream_index = input.index();
+pub fn get_clip_info(source: &Path) -> anyhow::Result<ClipInfo> {
+    let output = Command::new("ffprobe")
+        .arg("-v")
+        .arg("quiet")
+        .arg("-select_streams")
+        .arg("v:0")
+        .arg("-print_format")
+        .arg("json")
+        .arg("-show_entries")
+        .arg("stream=width,height,pix_fmt,avg_frame_rate,nb_frames,color_transfer")
+        .arg(source)
+        .output()?
+        .stdout;
+    let ffprobe_info: FfProbeInfo = serde_json::from_slice(&output)?;
+    let stream_info = ffprobe_info
+        .streams
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("no video streams found in source file"))?;
 
     Ok(ClipInfo {
         format_info:              InputPixelFormat::FFmpeg {
-            format: get_pixel_format(&input)?,
+            format: FFPixelFormat::from_str(&stream_info.pix_fmt)?,
         },
-        frame_rate:               frame_rate(&input)?,
-        resolution:               resolution(&input)?,
-        transfer_characteristics: match transfer_characteristics(&input)? {
-            TransferCharacteristic::SMPTE2084 => av1_grain::TransferFunction::SMPTE2084,
+        frame_rate:               parse_frame_rate(&stream_info.avg_frame_rate)?,
+        resolution:               (stream_info.width, stream_info.height),
+        transfer_characteristics: match stream_info.color_transfer.as_deref() {
+            Some("smpte2084") => av1_grain::TransferFunction::SMPTE2084,
             _ => av1_grain::TransferFunction::BT1886,
         },
-        num_frames:               num_frames(&mut ictx, video_stream_index)?,
+        num_frames:               match stream_info.nb_frames {
+            Some(nb_frames) => nb_frames,
+            None => get_num_frames(source)?,
+        },
     })
 }
 
 /// Get frame count using FFmpeg
 #[inline]
-pub fn get_num_frames(source: &Path) -> Result<usize, ffmpeg::Error> {
-    let mut ictx = input(source)?;
-    let input = ictx.streams().best(MediaType::Video).ok_or(StreamNotFound)?;
-    let video_stream_index = input.index();
-    num_frames(&mut ictx, video_stream_index)
+pub fn get_num_frames(source: &Path) -> anyhow::Result<usize> {
+    let output = Command::new("ffprobe")
+        .arg("-v")
+        .arg("error")
+        .arg("-select_streams")
+        .arg("v:0")
+        .arg("-count_packets")
+        .arg("-show_entries")
+        .arg("stream=nb_read_packets")
+        .arg("-print_format")
+        .arg("csv=p=0")
+        .arg(source)
+        .output()?
+        .stdout;
+    match String::from_utf8_lossy(&output).parse::<usize>() {
+        Ok(x) if x > 0 => Ok(x),
+        _ => {
+            // If we got empty output or a 0 frame count, try using the slower
+            // but more reliable method
+            get_num_frames_slow(source)
+        },
+    }
 }
 
-fn num_frames(ictx: &mut Input, video_stream_index: usize) -> Result<usize, ffmpeg::Error> {
-    Ok(ictx
-        .packets()
-        .filter_map(Result::ok)
-        .filter(|(stream, _)| stream.index() == video_stream_index)
-        .count())
+/// Slower but more reliable frame count method
+fn get_num_frames_slow(source: &Path) -> anyhow::Result<usize> {
+    let output = Command::new("ffprobe")
+        .arg("-v")
+        .arg("error")
+        .arg("-count_frames")
+        .arg("-select_streams")
+        .arg("v:0")
+        .arg("-show_entries")
+        .arg("stream=nb_read_frames")
+        .arg("-print_format")
+        .arg("default=noprint_wrappers=1:nokey=1")
+        .arg(source)
+        .output()?
+        .stdout;
+    Ok(String::from_utf8_lossy(&output).parse::<usize>()?)
 }
 
-fn frame_rate(input: &Stream) -> Result<Rational64, ffmpeg::Error> {
-    let rate = input.avg_frame_rate();
+fn parse_frame_rate(rate: &str) -> anyhow::Result<Rational64> {
+    let (numer, denom) = rate
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("failed to parse frame rate from ffprobe output"))?;
     Ok(Rational64::new(
-        rate.numerator() as i64,
-        rate.denominator() as i64,
+        numer.parse::<i64>()?,
+        denom.parse::<i64>()?,
     ))
 }
 
-fn get_pixel_format(input: &Stream) -> Result<Pixel, ffmpeg::Error> {
-    let decoder = ffmpeg::codec::context::Context::from_parameters(input.parameters())?
-        .decoder()
-        .video()?;
-
-    Ok(decoder.format())
+#[derive(Debug, Clone, Deserialize)]
+struct FfProbeKeyframesData {
+    pub frames: Vec<FfProbeKeyframeFrame>,
 }
 
-fn resolution(input: &Stream) -> Result<(u32, u32), ffmpeg::Error> {
-    let decoder = ffmpeg::codec::context::Context::from_parameters(input.parameters())?
-        .decoder()
-        .video()?;
-
-    Ok((decoder.width(), decoder.height()))
-}
-
-fn transfer_characteristics(input: &Stream) -> Result<TransferCharacteristic, ffmpeg::Error> {
-    let decoder = ffmpeg::codec::context::Context::from_parameters(input.parameters())?
-        .decoder()
-        .video()?;
-
-    Ok(decoder.color_transfer_characteristic())
+#[derive(Debug, Clone, Deserialize)]
+struct FfProbeKeyframeFrame {
+    // 0 or 1
+    pub key_frame: u8,
 }
 
 /// Returns vec of all keyframes
 #[tracing::instrument(level = "debug")]
-pub fn get_keyframes(source: &Path) -> Result<Vec<usize>, ffmpeg::Error> {
-    let mut ictx = input(source)?;
-    let input = ictx.streams().best(MediaType::Video).ok_or(StreamNotFound)?;
-    let video_stream_index = input.index();
-
-    let kfs = ictx
-        .packets()
-        .filter_map(Result::ok)
-        .filter(|(stream, _)| stream.index() == video_stream_index)
-        .map(|(_, packet)| packet)
+pub fn get_keyframes(source: &Path) -> anyhow::Result<Vec<usize>> {
+    // This is slow because it has to iterate through the whole video,
+    // but it is the best suggestion that reliably worked
+    // since not all codecs code "coded_picture_number" into the frames.
+    let output = Command::new("ffprobe")
+        .arg("-v")
+        .arg("quiet")
+        .arg("-print_format")
+        .arg("json")
+        .arg("-show_frames")
+        .arg("-select_streams")
+        .arg("v:0")
+        .arg("show_entries")
+        .arg("frame=key_frame")
+        .arg(source)
+        .output()?
+        .stdout;
+    let frames = serde_json::from_slice::<FfProbeKeyframesData>(&output)?.frames;
+    Ok(frames
+        .into_iter()
         .enumerate()
-        .filter(|(_, packet)| packet.is_key())
-        .map(|(i, _)| i)
-        .collect::<Vec<_>>();
-
-    if kfs.is_empty() {
-        return Ok(vec![0]);
-    };
-
-    Ok(kfs)
+        .filter_map(|(i, frame)| if frame.key_frame > 0 { Some(i) } else { None })
+        .collect())
 }
 
 /// Returns true if input file have audio in it
-#[must_use]
 #[inline]
-pub fn has_audio(file: &Path) -> bool {
-    let ictx = input(file).unwrap();
-    ictx.streams().best(MediaType::Audio).is_some()
+pub fn has_audio(file: &Path) -> anyhow::Result<bool> {
+    let output = Command::new("ffprobe")
+        .arg("-v")
+        .arg("error")
+        .arg("-select_streams")
+        .arg("a")
+        .arg("-show_entries")
+        .arg("stream=index")
+        .arg("-of")
+        .arg("csv=p=0")
+        .arg(file)
+        .output()?
+        .stdout;
+    let output = String::from_utf8_lossy(&output);
+    Ok(!output.trim().is_empty())
 }
 
 /// Encodes the audio using FFmpeg, blocking the current thread.
@@ -155,7 +213,7 @@ pub fn encode_audio<S: AsRef<OsStr>>(
     let input = input.as_ref();
     let temp = temp.as_ref();
 
-    if has_audio(input) {
+    if has_audio(input).unwrap() {
         let audio_file = Path::new(temp).join("audio.mkv");
         let mut encode_audio = Command::new("ffmpeg");
 
@@ -201,4 +259,114 @@ pub fn escape_path_in_filter(path: impl AsRef<Path>) -> String {
     .replace('[', r"\[")
     .replace(']', r"\]")
     .replace(',', "\\,")
+}
+
+/// Pixel formats supported by ffmpeg
+#[allow(non_camel_case_types)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum FFPixelFormat {
+    GBRP,
+    GBRP10LE,
+    GBRP12L,
+    GBRP12LE,
+    GRAY10LE,
+    GRAY12L,
+    GRAY12LE,
+    GRAY8,
+    NV12,
+    NV16,
+    NV20LE,
+    NV21,
+    YUV420P,
+    YUV420P10LE,
+    YUV420P12LE,
+    YUV422P,
+    YUV422P10LE,
+    YUV422P12LE,
+    YUV440P,
+    YUV440P10LE,
+    YUV440P12LE,
+    YUV444P,
+    YUV444P10LE,
+    YUV444P12LE,
+    YUVA420P,
+    YUVJ420P,
+    YUVJ422P,
+    YUVJ444P,
+}
+
+impl FFPixelFormat {
+    /// The string to be used with ffmpeg's `-pix_fmt` argument.
+    #[inline]
+    pub fn to_pix_fmt_string(&self) -> &'static str {
+        match self {
+            FFPixelFormat::GBRP => "gbrp",
+            FFPixelFormat::GBRP10LE => "gbrp10le",
+            FFPixelFormat::GBRP12L => "gbrp12l",
+            FFPixelFormat::GBRP12LE => "gbrp12le",
+            FFPixelFormat::GRAY10LE => "gray10le",
+            FFPixelFormat::GRAY12L => "gray12l",
+            FFPixelFormat::GRAY12LE => "gray12le",
+            FFPixelFormat::GRAY8 => "gray",
+            FFPixelFormat::NV12 => "nv12",
+            FFPixelFormat::NV16 => "nv16",
+            FFPixelFormat::NV20LE => "nv20le",
+            FFPixelFormat::NV21 => "nv21",
+            FFPixelFormat::YUV420P => "yuv420p",
+            FFPixelFormat::YUV420P10LE => "yuv420p10le",
+            FFPixelFormat::YUV420P12LE => "yuv420p12le",
+            FFPixelFormat::YUV422P => "yuv422p",
+            FFPixelFormat::YUV422P10LE => "yuv422p10le",
+            FFPixelFormat::YUV422P12LE => "yuv422p12le",
+            FFPixelFormat::YUV440P => "yuv440p",
+            FFPixelFormat::YUV440P10LE => "yuv440p10le",
+            FFPixelFormat::YUV440P12LE => "yuv440p12le",
+            FFPixelFormat::YUV444P => "yuv444p",
+            FFPixelFormat::YUV444P10LE => "yuv444p10le",
+            FFPixelFormat::YUV444P12LE => "yuv444p12le",
+            FFPixelFormat::YUVA420P => "yuva420p",
+            FFPixelFormat::YUVJ420P => "yuvj420p",
+            FFPixelFormat::YUVJ422P => "yuvj422p",
+            FFPixelFormat::YUVJ444P => "yuvj444p",
+        }
+    }
+}
+
+impl FromStr for FFPixelFormat {
+    type Err = anyhow::Error;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "gbrp" => FFPixelFormat::GBRP,
+            "gbrp10le" => FFPixelFormat::GBRP10LE,
+            "gbrp12l" => FFPixelFormat::GBRP12L,
+            "gbrp12le" => FFPixelFormat::GBRP12LE,
+            "gray10le" => FFPixelFormat::GRAY10LE,
+            "gray12l" => FFPixelFormat::GRAY12L,
+            "gray12le" => FFPixelFormat::GRAY12LE,
+            "gray" => FFPixelFormat::GRAY8,
+            "nv12" => FFPixelFormat::NV12,
+            "nv16" => FFPixelFormat::NV16,
+            "nv20le" => FFPixelFormat::NV20LE,
+            "nv21" => FFPixelFormat::NV21,
+            "yuv420p" => FFPixelFormat::YUV420P,
+            "yuv420p10le" => FFPixelFormat::YUV420P10LE,
+            "yuv420p12le" => FFPixelFormat::YUV420P12LE,
+            "yuv422p" => FFPixelFormat::YUV422P,
+            "yuv422p10le" => FFPixelFormat::YUV422P10LE,
+            "yuv422p12le" => FFPixelFormat::YUV422P12LE,
+            "yuv440p" => FFPixelFormat::YUV440P,
+            "yuv440p10le" => FFPixelFormat::YUV440P10LE,
+            "yuv440p12le" => FFPixelFormat::YUV440P12LE,
+            "yuv444p" => FFPixelFormat::YUV444P,
+            "yuv444p10le" => FFPixelFormat::YUV444P10LE,
+            "yuv444p12le" => FFPixelFormat::YUV444P12LE,
+            "yuva420p" => FFPixelFormat::YUVA420P,
+            "yuvj420p" => FFPixelFormat::YUVJ420P,
+            "yuvj422p" => FFPixelFormat::YUVJ422P,
+            "yuvj444p" => FFPixelFormat::YUVJ444P,
+            _ => bail!("Unsupported pixel format string"),
+        })
+    }
 }

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -11,7 +11,6 @@ use std::{
     time::Instant,
 };
 
-use ::ffmpeg::format::Pixel;
 use ::vapoursynth::{api::API, map::OwnedMap};
 use anyhow::{bail, Context};
 use av1_grain::TransferFunction;
@@ -33,6 +32,7 @@ pub use crate::{
     util::read_in_dir,
 };
 use crate::{
+    ffmpeg::FFPixelFormat,
     progress_bar::finish_progress_bar,
     vapoursynth::{create_vs_file, generate_loadscript_text},
 };
@@ -102,7 +102,7 @@ impl Input {
         temporary_directory: &str,
         chunk_method: ChunkMethod,
         scene_detection_downscale_height: Option<usize>,
-        scene_detection_pixel_format: Option<Pixel>,
+        scene_detection_pixel_format: Option<FFPixelFormat>,
         scene_detection_scaler: Option<String>,
         is_proxy: bool,
     ) -> anyhow::Result<Self> {
@@ -226,7 +226,7 @@ impl Input {
     pub fn as_script_text(
         &self,
         scene_detection_downscale_height: Option<usize>,
-        scene_detection_pixel_format: Option<Pixel>,
+        scene_detection_pixel_format: Option<FFPixelFormat>,
         scene_detection_scaler: Option<String>,
     ) -> anyhow::Result<String> {
         match &self {
@@ -593,8 +593,8 @@ pub fn determine_workers(args: &EncodeArgs) -> anyhow::Result<u64> {
     // memory usage scales with pixel format, expressed as a multiplier of memory
     // usage. Roughly the same behavior was observed accross all encoders.
     let pix_mult = match args.output_pix_format.format {
-        Pixel::YUV444P | Pixel::YUV444P10LE | Pixel::YUV444P12LE => 1.5,
-        Pixel::YUV422P | Pixel::YUV422P10LE | Pixel::YUV422P12LE => 1.25,
+        FFPixelFormat::YUV444P | FFPixelFormat::YUV444P10LE | FFPixelFormat::YUV444P12LE => 1.5,
+        FFPixelFormat::YUV422P | FFPixelFormat::YUV422P10LE | FFPixelFormat::YUV422P12LE => 1.25,
         _ => 1.0,
     };
 

--- a/av1an-core/src/scenes/tests.rs
+++ b/av1an-core/src/scenes/tests.rs
@@ -7,10 +7,9 @@ use crate::{
 fn get_test_args() -> Av1anContext {
     use std::path::PathBuf;
 
-    use ffmpeg::format::Pixel;
-
     use crate::{
         concat::ConcatMethod,
+        ffmpeg::FFPixelFormat,
         into_vec,
         settings::{EncodeArgs, InputPixelFormat, PixelFormat},
         ChunkMethod,
@@ -43,7 +42,7 @@ fn get_test_args() -> Av1anContext {
         max_tries:             3,
         min_scene_len:         10,
         input_pix_format:      InputPixelFormat::FFmpeg {
-            format: Pixel::YUV420P10LE,
+            format: FFPixelFormat::YUV420P10LE,
         },
         input:                 Input::Video {
             path:         PathBuf::new(),
@@ -53,7 +52,7 @@ fn get_test_args() -> Av1anContext {
         },
         proxy:                 None,
         output_pix_format:     PixelFormat {
-            format:    Pixel::YUV420P10LE,
+            format:    FFPixelFormat::YUV420P10LE,
             bit_depth: 10,
         },
         resume:                false,

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use anyhow::{bail, ensure};
-use ffmpeg::format::Pixel;
 use itertools::{chain, Itertools};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -15,6 +14,7 @@ use tracing::warn;
 use crate::{
     concat::ConcatMethod,
     encoder::Encoder,
+    ffmpeg::FFPixelFormat,
     metrics::{vmaf::validate_libvmaf, xpsnr::validate_libxpsnr},
     parse::valid_params,
     target_quality::TargetQuality,
@@ -31,14 +31,14 @@ use crate::{
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct PixelFormat {
-    pub format:    Pixel,
+    pub format:    FFPixelFormat,
     pub bit_depth: usize,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum InputPixelFormat {
     VapourSynth { bit_depth: usize },
-    FFmpeg { format: Pixel },
+    FFmpeg { format: FFPixelFormat },
 }
 
 impl InputPixelFormat {
@@ -55,7 +55,7 @@ impl InputPixelFormat {
     }
 
     #[inline]
-    pub fn as_pixel_format(&self) -> anyhow::Result<Pixel> {
+    pub fn as_pixel_format(&self) -> anyhow::Result<FFPixelFormat> {
         match self {
             InputPixelFormat::VapourSynth {
                 ..
@@ -80,7 +80,7 @@ pub struct EncodeArgs {
     pub scaler:                String,
     pub scenes:                Option<PathBuf>,
     pub split_method:          SplitMethod,
-    pub sc_pix_format:         Option<Pixel>,
+    pub sc_pix_format:         Option<FFPixelFormat>,
     pub sc_method:             ScenecutMethod,
     pub sc_only:               bool,
     pub sc_downscale_height:   Option<usize>,

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -10,13 +10,13 @@ use std::{
 };
 
 use anyhow::bail;
-use ffmpeg::format::Pixel;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
 
 use crate::{
     broker::EncoderCrash,
     chunk::Chunk,
+    ffmpeg::FFPixelFormat,
     interpol::{
         akima_interpolate,
         catmull_rom_interpolate,
@@ -88,7 +88,7 @@ pub struct TargetQuality {
     pub max_q:                 u32,
     pub interp_method:         Option<(InterpolationMethod, InterpolationMethod)>,
     pub encoder:               Encoder,
-    pub pix_format:            Pixel,
+    pub pix_format:            FFPixelFormat,
     pub temp:                  String,
     pub workers:               usize,
     pub video_params:          Vec<String>,

--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -18,6 +18,7 @@ use vapoursynth::{
 
 use super::ChunkMethod;
 use crate::{
+    ffmpeg::FFPixelFormat,
     metrics::{
         butteraugli::ButteraugliSubMetric,
         xpsnr::{weight_xpsnr, XPSNRSubMetric},
@@ -724,7 +725,7 @@ pub fn create_vs_file(
     source: &Path,
     chunk_method: ChunkMethod,
     scene_detection_downscale_height: Option<usize>,
-    scene_detection_pixel_format: Option<ffmpeg::format::Pixel>,
+    scene_detection_pixel_format: Option<FFPixelFormat>,
     scene_detection_scaler: String,
     is_proxy: bool,
 ) -> anyhow::Result<(PathBuf, bool)> {
@@ -780,7 +781,7 @@ pub fn generate_loadscript_text(
     source: &Path,
     chunk_method: ChunkMethod,
     scene_detection_downscale_height: Option<usize>,
-    scene_detection_pixel_format: Option<ffmpeg::format::Pixel>,
+    scene_detection_pixel_format: Option<FFPixelFormat>,
     scene_detection_scaler: String,
     is_proxy: bool,
 ) -> anyhow::Result<(String, bool)> {

--- a/av1an/Cargo.toml
+++ b/av1an/Cargo.toml
@@ -22,7 +22,6 @@ anyhow = { workspace = true }
 av1an-core = { path = "../av1an-core", version = "0.4.1" }
 clap = { version = "4.5.41", features = ["derive"] }
 clap_complete = "4.5.54"
-ffmpeg = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }
 path_abs = { workspace = true }
@@ -36,4 +35,3 @@ vergen-git2 = { version = "1.0.0", features = ["build", "rustc", "cargo"] }
 
 [features]
 default = []
-ffmpeg_static = ["ffmpeg/static", "ffmpeg/build", "av1an-core/ffmpeg_static"]

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -7,9 +7,9 @@ use std::{
     thread::available_parallelism,
 };
 
-use ::ffmpeg::format::Pixel;
 use anyhow::{anyhow, bail, ensure, Context};
 use av1an_core::{
+    ffmpeg::FFPixelFormat,
     hash_path,
     into_vec,
     read_in_dir,
@@ -335,7 +335,7 @@ pub struct CliOpts {
 
     /// Perform scene detection with this pixel format
     #[clap(long, help_heading = "Scene Detection")]
-    pub sc_pix_format: Option<Pixel>,
+    pub sc_pix_format: Option<FFPixelFormat>,
 
     /// Maximum scene length
     ///
@@ -555,7 +555,7 @@ pub struct CliOpts {
 
     /// FFmpeg pixel format
     #[clap(long, default_value = "yuv420p10le", help_heading = "Encoding")]
-    pub pix_format: Pixel,
+    pub pix_format: FFPixelFormat,
 
     /// Path to a file specifying zones within the video with differing encoder
     /// settings.
@@ -829,7 +829,7 @@ impl CliOpts {
         &self,
         temp_dir: String,
         video_params: Vec<String>,
-        output_pix_format: Pixel,
+        output_pix_format: FFPixelFormat,
     ) -> anyhow::Result<Option<TargetQuality>> {
         self.target_quality
             .map(|tq| {


### PR DESCRIPTION
This avoids the need to link against ffmpeg when building av1an, and instead uses the ffmpeg/ffprobe binaries in all places where we need it. We were already using the binaries in the majority of places, so this simply results in an improvement for setup for the end user, as linking against ffmpeg was a particular pain point.