### PR TITLE
improve VMAF & small refactor

### DIFF
--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -488,7 +488,10 @@ impl Av1anContext {
                         1,
                         vmaf_filter,
                         vmaf_threads,
-                        &[],
+                        self.args
+                            .target_quality
+                            .as_ref()
+                            .map_or(&[], |tq| &tq.probing_vmaf_features),
                     ) {
                         error!("VMAF calculation failed with error: {e}");
                     }

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -488,6 +488,7 @@ impl Av1anContext {
                         1,
                         vmaf_filter,
                         vmaf_threads,
+                        &[],
                     ) {
                         error!("VMAF calculation failed with error: {e}");
                     }

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -29,7 +29,7 @@ use crate::{
     metrics::{
         butteraugli::ButteraugliSubMetric,
         statistics::MetricStatistics,
-        vmaf::{read_vmaf_file, run_vmaf, run_vmaf_weighted},
+        vmaf::{get_vmaf_model_version, read_vmaf_file, run_vmaf, run_vmaf_weighted},
         xpsnr::{read_xpsnr_file, run_xpsnr, XPSNRSubMetric},
     },
     progress_bar::update_mp_msg,
@@ -375,16 +375,12 @@ impl TargetQuality {
             TargetMetric::VMAF => {
                 let features: HashSet<_> = self.probing_vmaf_features.iter().copied().collect();
                 let use_weighted = features.contains(&VmafFeature::Weighted);
-                let use_neg = features.contains(&VmafFeature::Neg);
-                let use_uhd = features.contains(&VmafFeature::Uhd);
                 let disable_motion = features.contains(&VmafFeature::Motionless);
 
-                let default_model = match (use_uhd, use_neg) {
-                    (true, true) => Some(PathBuf::from("vmaf_4k_v0.6.1neg.json")),
-                    (true, false) => Some(PathBuf::from("vmaf_4k_v0.6.1.json")),
-                    (false, true) => Some(PathBuf::from("vmaf_v0.6.1neg.json")),
-                    (false, false) => None,
-                };
+                let default_model = Some(PathBuf::from(format!(
+                    "{}.json",
+                    get_vmaf_model_version(&self.probing_vmaf_features)
+                )));
 
                 let model = if self.model.is_none() {
                     default_model.as_ref()
@@ -405,6 +401,7 @@ impl TargetQuality {
                         self.vmaf_threads,
                         chunk.frame_rate,
                         disable_motion,
+                        &self.probing_vmaf_features,
                     )
                     .map_err(|e| {
                         Box::new(EncoderCrash {
@@ -433,6 +430,7 @@ impl TargetQuality {
                         self.vmaf_threads,
                         chunk.frame_rate,
                         disable_motion,
+                        &self.probing_vmaf_features,
                     )?;
 
                     read_vmaf_file(&fl_path)?

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -377,13 +377,25 @@ impl TargetQuality {
                 let use_weighted = features.contains(&VmafFeature::Weighted);
                 let disable_motion = features.contains(&VmafFeature::Motionless);
 
-                let model = if self.model.is_some() {
-                    self.model.as_ref()
+                // TODO: Update when nightly changes come to stable (2025-07-15)
+                //   let model = if self.model.is_some() {
+                //     self.model.as_ref()
+                // } else {
+                //     some(&pathbuf::from(format!(
+                //         "{}.json",
+                //         get_vmaf_model_version(&self.probing_vmaf_features)
+                //     )))
+                // };
+
+                let default_model = Some(PathBuf::from(format!(
+                    "{}.json",
+                    get_vmaf_model_version(&self.probing_vmaf_features)
+                )));
+
+                let model = if self.model.is_none() {
+                    default_model.as_ref()
                 } else {
-                    Some(&PathBuf::from(format!(
-                        "{}.json",
-                        get_vmaf_model_version(&self.probing_vmaf_features)
-                    )))
+                    self.model.as_ref()
                 };
 
                 let vmaf_scores = if use_weighted {

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -377,15 +377,13 @@ impl TargetQuality {
                 let use_weighted = features.contains(&VmafFeature::Weighted);
                 let disable_motion = features.contains(&VmafFeature::Motionless);
 
-                let default_model = Some(PathBuf::from(format!(
-                    "{}.json",
-                    get_vmaf_model_version(&self.probing_vmaf_features)
-                )));
-
-                let model = if self.model.is_none() {
-                    default_model.as_ref()
-                } else {
+                let model = if self.model.is_some() {
                     self.model.as_ref()
+                } else {
+                    Some(&PathBuf::from(format!(
+                        "{}.json",
+                        get_vmaf_model_version(&self.probing_vmaf_features)
+                    )))
                 };
 
                 let vmaf_scores = if use_weighted {


### PR DESCRIPTION
A user reported a problem where they couldn't use NEG and UHD features combined.
I could reproduce it and added the fix along with some improvements:

- Centralizes VMAF model selection logic into a single function instead of duplicating the same conditional logic across multiple places.
- Eliminates hardcoded model name checks by replacing exact string matching with simple detection
- Makes VMAF model selection consistent across all functions by ensuring the same feature-based logic is used everywhere
- Fixes inconsistent default model behavior where some cases used no model while others used hardcoded models
- Removes code duplication by replacing repeated match statements for model selection with a single reusable function
- Prepares the codebase for dynamic VMAF feature configuration by threading the feature parameters through the entire call chain