### PR TITLE
Add score-based enhanced extra splits method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,11 @@ once_cell = "1.8.0"
 path_abs = "0.5.1"
 tracing = "0.1"
 
-[profile.dev.package.av-scenechange]
-opt-level = 3
+[profile.dev.package."*"]
+opt-level = 2
+
+[profile.dev]
+opt-level = 1
 
 [profile.release]
 lto = "thin"

--- a/av1an-core/src/scenes.rs
+++ b/av1an-core/src/scenes.rs
@@ -2,7 +2,7 @@
 mod tests;
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fs::File,
     io::Write,
     path::Path,
@@ -371,7 +371,7 @@ impl SceneFactory {
 
         let frames = args.input.clip_info()?.num_frames;
 
-        let (mut scenes, frames) = match args.split_method {
+        let (mut scenes, frames, scores) = match args.split_method {
             SplitMethod::AvScenechange => av_scenechange_detect(
                 args.proxy.as_ref().unwrap_or(&args.input),
                 args.encoder,
@@ -411,7 +411,7 @@ impl SceneFactory {
                         zone_overrides: None,
                     });
                 }
-                (scenes, frames)
+                (scenes, frames, BTreeMap::new())
             },
         };
 
@@ -440,14 +440,23 @@ impl SceneFactory {
             }
         }
 
+        if let Some(scene) = scenes.last() {
+            assert!(
+                scene.end_frame <= frames,
+                "scenecut reported at frame {}, but there are only {} frames",
+                scene.end_frame,
+                frames
+            );
+        }
+
         let scenes_before = scenes.len();
         self.data.scenes = Some(scenes);
 
         if let Some(split_len @ 1..) = args.extra_splits_len {
             self.data.split_scenes = Some(extra_splits(
                 self.data.scenes.as_deref().unwrap(),
-                frames,
                 split_len,
+                &scores,
             ));
             let scenes_after = self.data.split_scenes.as_ref().unwrap().len();
             info!(

--- a/av1an-core/src/split.rs
+++ b/av1an-core/src/split.rs
@@ -2,10 +2,14 @@
 mod tests;
 
 use std::{
+    cmp::min,
+    collections::BTreeMap,
     path::Path,
     process::{Command, Stdio},
     string::ToString,
 };
+
+use av_scenechange::ScenecutResult;
 
 use crate::scenes::Scene;
 
@@ -37,17 +41,31 @@ pub fn segment(input: impl AsRef<Path>, temp: impl AsRef<Path>, segments: &[usiz
     assert!(out.status.success(), "FFmpeg failed to segment: {out:#?}");
 }
 
-pub fn extra_splits(scenes: &[Scene], total_frames: usize, split_size: usize) -> Vec<Scene> {
-    let mut new_scenes: Vec<Scene> = Vec::with_capacity(scenes.len());
-
-    if let Some(scene) = scenes.last() {
-        assert!(
-            scene.end_frame <= total_frames,
-            "scenecut reported at index {}, but there are only {} frames",
-            scene.end_frame,
-            total_frames
-        );
+pub fn extra_splits(
+    scenes: &[Scene],
+    split_size: usize,
+    scores: &BTreeMap<usize, ScenecutResult>,
+) -> Vec<Scene> {
+    if scores.is_empty() {
+        // This is most likely to occur when the user specifies no scene detection
+        simple_extra_splits(scenes, split_size)
+    } else {
+        enhanced_extra_splits(scenes, split_size, scores)
     }
+}
+
+/// This is a simple, cut right in the middle method for creating extra splits.
+///
+/// This function assumes that `scenes` is a contiguous and sorted list
+fn simple_extra_splits(scenes: &[Scene], split_size: usize) -> Vec<Scene> {
+    if cfg!(debug_assertions) {
+        // In debug mode, validate that `scenes` is a contiguous and sorted list
+        for window in scenes.windows(2) {
+            assert_eq!(window[0].end_frame, window[1].start_frame);
+        }
+    }
+
+    let mut new_scenes: Vec<Scene> = Vec::with_capacity(scenes.len());
 
     for scene in scenes {
         let distance = scene.end_frame - scene.start_frame;
@@ -68,6 +86,88 @@ pub fn extra_splits(scenes: &[Scene], total_frames: usize, split_size: usize) ->
                     ..scene.clone()
                 });
             }
+        }
+        new_scenes.push(Scene {
+            start_frame: new_scenes.last().map_or(scene.start_frame, |scene| scene.end_frame),
+            end_frame: scene.end_frame,
+            ..scene.clone()
+        });
+    }
+
+    new_scenes
+}
+
+/// This is an enhanced extra splits method that attempts to choose the optimal
+/// location for the extra split based on the scenecut scores and the sizes
+/// of the resulting scenes. It tries to avoid bad extra splits without
+/// making one scene that is very small compared to the other.
+///
+/// This function assumes that `scenes` is a contiguous and sorted list
+fn enhanced_extra_splits(
+    scenes: &[Scene],
+    split_size: usize,
+    scores: &BTreeMap<usize, ScenecutResult>,
+) -> Vec<Scene> {
+    if cfg!(debug_assertions) {
+        // In debug mode, validate that `scenes` is a contiguous and sorted list
+        for window in scenes.windows(2) {
+            assert_eq!(window[0].end_frame, window[1].start_frame);
+        }
+    }
+
+    let mut new_scenes: Vec<Scene> = Vec::with_capacity(scenes.len());
+
+    for scene in scenes {
+        let mut distance = scene.end_frame - scene.start_frame;
+        let split_size = scene
+            .zone_overrides
+            .as_ref()
+            .map_or(split_size, |ovr| ovr.extra_splits_len.unwrap_or(usize::MAX));
+        while distance > split_size {
+            let minimum_split_count = distance / split_size;
+            let middle_point = distance / (minimum_split_count + 1);
+
+            // To avoid potentially harmful decisions, limit the search range
+            let min_size = middle_point / 2;
+            let max_size = min(split_size, middle_point + min_size);
+            let range_size = max_size - min_size;
+            debug_assert!(max_size >= min_size);
+            debug_assert!(max_size <= split_size);
+
+            let start_frame = new_scenes.last().map_or(scene.start_frame, |scene| scene.end_frame);
+
+            // A list mapping split sizes to their scores
+            let split_scores = (min_size..=max_size)
+                .filter_map(|size| {
+                    scores.get(&(start_frame + size)).map(|scores| {
+                        let inter_score = scores.inter_cost / scores.threshold;
+                        let distance_from_mid = (middle_point as i64 - size as i64).abs() as f64;
+                        debug_assert!(distance_from_mid as usize <= range_size);
+                        // Currently the weighting is linear, starting at 1.0x
+                        // in the middle and going down to 0.5x at the ends
+                        let distance_weighting = 1.0 - distance_from_mid / range_size as f64;
+                        let weighted_score = inter_score * distance_weighting;
+                        (size, weighted_score)
+                    })
+                })
+                .collect::<Vec<(usize, f64)>>();
+            let split_point = split_scores
+                .iter()
+                .max_by_key(|(_, score)| {
+                    // This should be enough precision.
+                    // It would be great if there was a `NonNaNF64` type that implemented `Ord`.
+                    (*score * 10000.0).round() as u64
+                })
+                .expect("split scores is not empty")
+                .0;
+
+            let new_scene = Scene {
+                start_frame,
+                end_frame: start_frame + split_point,
+                ..scene.clone()
+            };
+            distance = scene.end_frame - new_scene.end_frame;
+            new_scenes.push(new_scene);
         }
         new_scenes.push(Scene {
             start_frame: new_scenes.last().map_or(scene.start_frame, |scene| scene.end_frame),

--- a/av1an-core/src/split/tests.rs
+++ b/av1an-core/src/split/tests.rs
@@ -3,7 +3,6 @@ use crate::{encoder::Encoder, into_vec, scenes::ZoneOptions};
 
 #[test]
 fn test_extra_split_no_segments() {
-    let total_frames = 300;
     let split_size = 240;
     let done = extra_splits(
         &[Scene {
@@ -11,8 +10,8 @@ fn test_extra_split_no_segments() {
             end_frame:      300,
             zone_overrides: None,
         }],
-        total_frames,
         split_size,
+        &BTreeMap::new(),
     );
     let expected_split_locations = vec![0usize, 150];
 
@@ -24,7 +23,6 @@ fn test_extra_split_no_segments() {
 
 #[test]
 fn test_extra_split_segments() {
-    let total_frames = 2000;
     let split_size = 130;
     let done = extra_splits(
         &[
@@ -79,8 +77,8 @@ fn test_extra_split_segments() {
                 zone_overrides: None,
             },
         ],
-        total_frames,
         split_size,
+        &BTreeMap::new(),
     );
     let expected_split_locations = [
         0usize, 75, 150, 253, 356, 460, 549, 638, 728, 822, 876, 890, 995, 1100, 1199, 1299, 1399,
@@ -95,7 +93,6 @@ fn test_extra_split_segments() {
 
 #[test]
 fn test_extra_split_preserves_zone_overrides() {
-    let total_frames = 2000;
     let split_size = 130;
     let done = extra_splits(
         &[
@@ -170,8 +167,8 @@ fn test_extra_split_preserves_zone_overrides() {
                 zone_overrides: None,
             },
         ],
-        total_frames,
         split_size,
+        &BTreeMap::new(),
     );
     let expected_split_locations = [
         0, 75, 150, 253, 356, 460, 504, 549, 594, 638, 683, 728, 822, 876, 890, 995, 1100, 1199,


### PR DESCRIPTION
The goal of this change is to improve the locations chosen for extra splits, rather than being exactly in the middle, to being weighted based on a combination of scenecut cost and distance from the middle.

This fixes the distance calculation from the previous version.

Closes #1035