### PR TITLE
Remove parking_lot dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,6 @@ dependencies = [
  "nom 8.0.0",
  "num-traits",
  "once_cell",
- "parking_lot",
  "pastey",
  "path_abs",
  "plotters",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -37,7 +37,6 @@ memchr = "2.7.5"
 nom = "8.0.0"
 num-traits = { workspace = true }
 once_cell = { workspace = true }
-parking_lot = "0.12.4"
 pastey = "0.1.0"
 path_abs = { workspace = true }
 plotters = { version = "0.3.1", default-features = false, features = [

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -6,7 +6,10 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     string::ToString,
-    sync::atomic::{AtomicBool, AtomicUsize},
+    sync::{
+        atomic::{AtomicBool, AtomicUsize},
+        Mutex,
+    },
     thread::available_parallelism,
     time::Instant,
 };
@@ -18,7 +21,6 @@ use av_format::rational::Rational64;
 use chunk::Chunk;
 use dashmap::DashMap;
 use once_cell::sync::{Lazy, OnceCell};
-use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, FromRepr, IntoStaticStr};
 use tracing::info;
@@ -328,7 +330,7 @@ impl Input {
     pub fn clip_info(&self) -> anyhow::Result<ClipInfo> {
         const FAIL_MSG: &str = "Failed to get number of frames for input video";
 
-        let mut cache = CLIP_INFO_CACHE.lock();
+        let mut cache = CLIP_INFO_CACHE.lock().unwrap();
         let key = CacheKey {
             input:    self.clone(),
             is_proxy: self.is_proxy(),


### PR DESCRIPTION
As of Rust 1.62 the `std::sync::Mutex` was refactored to make its performance comparable to `parking_lot::Mutex`, which means there's no need for us to import this additional dependency anymore.

This also found and fixed and issue where we were creating a lock twice for every line of stderr parsing, which should reduce performance overhead.