### PR TITLE
Fix log file does not accept absolute paths

### DIFF
--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -215,9 +215,10 @@ pub struct CliOpts {
     #[clap(long)]
     pub verbose: bool,
 
-    /// Log file location under ./logs [default: ./logs/av1an.log]
+    /// Log file location
     ///
-    /// Must be a relative path. Prepending with ./logs is optional.
+    /// If not specified, the log file location will be `./logs/av1an.log` and
+    /// the current day will be appended.
     #[clap(short, long)]
     pub log_file: Option<String>,
 
@@ -1282,7 +1283,7 @@ pub fn run() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let log_file = cli_options.log_file.as_ref().map(PathBuf::from);
+    let log_file = cli_options.log_file.as_ref().map(PathAbs::new).transpose()?;
     let log_level = cli_options.log_level;
     let verbosity = {
         if cli_options.quiet {
@@ -1301,7 +1302,7 @@ pub fn run() -> anyhow::Result<()> {
             Verbosity::Normal => LevelFilter::INFO,
             Verbosity::Verbose => LevelFilter::INFO,
         },
-        log_file.as_deref(),
+        log_file,
         log_level,
     )?;
 


### PR DESCRIPTION
An improvement over PR #956

`--log-file PATH` now supports absolute file paths as well as relative file paths.

Previously I could not figure out how to support absolute paths as an input to RollingFileAppender. Now it just inexplicably works. No need to require relatives paths to a `./logs` directory from the user anymore - they can put the log file anywhere they want. If the `--log-file` is not specified, it uses the default behavior of putting it `./logs/av1an.log` and appends a date. Dates are not appended to the user-specified path as doing so could be considered unexpected behavior.

## Caveats

If you try to write a log file to a folder that has restricted permissions such as `C:/AmIAllowedToBeHere.log`, RollingFileAppender will panic instead of bubbling the error up to us. Perhaps we should make a macro or something to create a temporary file in any user-specified path and test for that failure condition before we try to do anything.

Thanks,
\- Boats McGee