### PR TITLE
Improvements to decoding frame accuracy

### DIFF
--- a/av1an-core/src/vapoursynth.rs
+++ b/av1an-core/src/vapoursynth.rs
@@ -43,14 +43,14 @@ pub struct VapoursynthPlugins {
 impl VapoursynthPlugins {
     #[inline]
     pub fn best_available_chunk_method(&self) -> ChunkMethod {
-        if self.lsmash {
+        if self.bestsource {
+            ChunkMethod::BESTSOURCE
+        } else if self.lsmash {
             ChunkMethod::LSMASH
         } else if self.ffms2 {
             ChunkMethod::FFMS2
         } else if self.dgdecnv {
             ChunkMethod::DGDECNV
-        } else if self.bestsource {
-            ChunkMethod::BESTSOURCE
         } else {
             ChunkMethod::Hybrid
         }

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -442,7 +442,11 @@ pub struct CliOpts {
     ///
     /// Methods that require an external vapoursynth plugin:
     ///
-    /// lsmash - Generally the best and most accurate method. Does not require
+    /// bestsource - Require a slow indexing pass once per file, but is the most
+    /// accurate. Does not require intermediate files, requires the BestSource
+    /// vapoursynth plugin to be installed.
+    ///
+    /// lsmash - Generally accurate and fast. Does not require
     /// intermediate files. Errors generally only occur if the input file
     /// itself is broken (for example, if the video bitstream is invalid in some
     /// way, video players usually try to recover from the errors as much as
@@ -450,18 +454,14 @@ pub struct CliOpts {
     /// instead throw an error). Requires the lsmashsource vapoursynth
     /// plugin to be installed.
     ///
-    /// ffms2 - Accurate and does not require intermediate files. Can sometimes
-    /// have bizarre bugs that are not present in lsmash (that can
+    /// ffms2 - Generally accurate and does not require intermediate files. Can
+    /// sometimes have bizarre bugs that are not present in lsmash (that can
     /// cause artifacts in the piped output). Slightly faster than lsmash for
     /// y4m input. Requires the ffms2 vapoursynth plugin to be installed.
     ///
     /// dgdecnv - Very fast, but only decodes AVC, HEVC, MPEG-2, and VC1. Does
     /// not require intermediate files. Requires dgindexnv to be present in
     /// system path, NVIDIA GPU that support CUDA video decoding, and dgdecnv
-    /// vapoursynth plugin to be installed.
-    ///
-    /// bestsource - Very slow but accurate. Linearly decodes input files, very
-    /// slow. Does not require intermediate files, requires the BestSource
     /// vapoursynth plugin to be installed.
     ///
     /// Methods that only require ffmpeg:
@@ -482,8 +482,8 @@ pub struct CliOpts {
     /// exact, as it can only split on keyframes in the source.
     /// Requires intermediate files (which can be large).
     ///
-    /// Default: lsmash (if available), otherwise ffms2 (if available),
-    /// otherwise DGDecNV (if available), otherwise bestsource (if available),
+    /// Default: bestsource (if available), otherwise lsmash (if available),
+    /// otherwise ffms2 (if available), otherwise DGDecNV (if available),
     /// otherwise hybrid.
     #[clap(short = 'm', long, help_heading = "Encoding")]
     pub chunk_method: Option<ChunkMethod>,


### PR DESCRIPTION
- Changes the default chunk method to `BestSource`. The filter is much faster than it used to be, now being equivalent to `ffms2` with the exception of the slow indexing pass, which only needs to be done once per input. This filter is now widely recommended as a sane default around the Vapoursynth community, so it seems sane to make this our default now as well.
- Use the same Vapoursynth source filter for scene detection that we use for chunking. This at least ensures consistent decoding even if there is a mismatch in frame accuracy.

Resolves a frame mismatch issue that was reported on Discord.