### PR TITLE
Fix FFmpeg VMAF fails to validate even when Target Quality is not used

### DIFF
--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -55,7 +55,7 @@ use crate::{
     settings::{EncodeArgs, InputPixelFormat},
     split::segment,
     vapoursynth::create_vs_file,
-    zones::parse_zones,
+    zones::{parse_zones, validate_zones},
     ChunkMethod,
     ChunkOrdering,
     DashMap,
@@ -843,6 +843,7 @@ impl Av1anContext {
             self.scene_factory = SceneFactory::from_scenes_file(&scene_file)?;
         } else {
             let zones = parse_zones(&self.args, self.frames)?;
+            validate_zones(&self.args, &zones)?;
             self.scene_factory.compute_scenes(&self.args, &zones)?;
             self.scene_factory.write_scenes_to_file(scene_file)?;
         }

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -174,92 +174,15 @@ impl EncodeArgs {
                 );
             }
         }
-        match self.target_quality.metric {
-            TargetMetric::VMAF => validate_libvmaf()?,
-            TargetMetric::SSIMULACRA2 => {
-                ensure!(
-                    self.vapoursynth_plugins.is_some_and(|p| p.vship)
-                        || self.vapoursynth_plugins.is_some_and(|p| p.vszip != VSZipVersion::None),
-                    "SSIMULACRA2 metric requires either Vapoursynth-HIP or VapourSynth Zig Image \
-                     Process to be installed"
-                );
-                ensure!(
-                    matches!(
-                        self.chunk_method,
-                        ChunkMethod::LSMASH
-                            | ChunkMethod::FFMS2
-                            | ChunkMethod::BESTSOURCE
-                            | ChunkMethod::DGDECNV
-                    ),
-                    "Chunk method must be lsmash, ffms2, bestsource, or dgdecnv for SSIMULACRA2"
-                );
-            },
-            TargetMetric::ButteraugliINF => {
-                ensure!(
-                    self.vapoursynth_plugins.is_some_and(|p| p.vship)
-                        || self.vapoursynth_plugins.is_some_and(|p| p.julek),
-                    "Butteraugli metric requires either Vapoursynth-HIP or \
-                     vapoursynth-julek-plugin to be installed"
-                );
-                ensure!(
-                    matches!(
-                        self.chunk_method,
-                        ChunkMethod::LSMASH
-                            | ChunkMethod::FFMS2
-                            | ChunkMethod::BESTSOURCE
-                            | ChunkMethod::DGDECNV
-                    ),
-                    "Chunk method must be lsmash, ffms2, bestsource, or dgdecnv for Butteraugli"
-                );
-            },
-            TargetMetric::Butteraugli3 => {
-                ensure!(
-                    self.vapoursynth_plugins.is_some_and(|p| p.vship),
-                    "Butteraugli 3 Norm metric requires Vapoursynth-HIP plugin to be installed"
-                );
-                ensure!(
-                    matches!(
-                        self.chunk_method,
-                        ChunkMethod::LSMASH
-                            | ChunkMethod::FFMS2
-                            | ChunkMethod::BESTSOURCE
-                            | ChunkMethod::DGDECNV
-                    ),
-                    "Chunk method must be lsmash, ffms2, bestsource, or dgdecnv for Butteraugli 3 \
-                     Norm"
-                );
-            },
-            TargetMetric::XPSNR | TargetMetric::XPSNRWeighted => {
-                let metric_name = if self.target_quality.metric == TargetMetric::XPSNRWeighted {
-                    "Weighted "
-                } else {
-                    ""
-                };
-                if self.target_quality.probing_rate > 1 {
-                    ensure!(
-                        self.vapoursynth_plugins.is_some_and(|p| p.vszip == VSZipVersion::New),
-                        format!(
-                            "{metric_name}XPSNR metric with probing rate greater than 1 requires \
-                             VapourSynth-Zig Image Process R7 or newer to be installed"
-                        )
-                    );
-                    ensure!(
-                        matches!(
-                            self.chunk_method,
-                            ChunkMethod::LSMASH
-                                | ChunkMethod::FFMS2
-                                | ChunkMethod::BESTSOURCE
-                                | ChunkMethod::DGDECNV
-                        ),
-                        format!(
-                            "Chunk method must be lsmash, ffms2, bestsource, or dgdecnv for \
-                             {metric_name}XPSNR with probing rate greater than 1"
-                        )
-                    );
-                } else {
-                    validate_libxpsnr()?;
-                }
-            },
+        if self.target_quality.target.is_some() {
+            match self.target_quality.metric {
+                TargetMetric::VMAF => validate_libvmaf()?,
+                TargetMetric::SSIMULACRA2 => self.validate_ssimululacra2()?,
+                TargetMetric::ButteraugliINF => self.validate_butteraugli_inf()?,
+                TargetMetric::Butteraugli3 => self.validate_butteraugli_3()?,
+                TargetMetric::XPSNR | TargetMetric::XPSNRWeighted => self
+                    .validate_xpsnr(self.target_quality.metric, self.target_quality.probing_rate)?,
+            }
         }
 
         if which::which("ffmpeg").is_err() {
@@ -501,6 +424,105 @@ impl EncodeArgs {
                 .iter()
                 .all(|&b| (b as char).is_ascii_digit())
         }
+    }
+
+    #[inline]
+    pub fn validate_ssimululacra2(&self) -> anyhow::Result<()> {
+        ensure!(
+            self.vapoursynth_plugins.is_some_and(|p| p.vship)
+                || self.vapoursynth_plugins.is_some_and(|p| p.vszip != VSZipVersion::None),
+            "SSIMULACRA2 metric requires either Vapoursynth-HIP or VapourSynth Zig Image Process \
+             to be installed"
+        );
+        ensure!(
+            matches!(
+                self.chunk_method,
+                ChunkMethod::LSMASH
+                    | ChunkMethod::FFMS2
+                    | ChunkMethod::BESTSOURCE
+                    | ChunkMethod::DGDECNV
+            ),
+            "Chunk method must be lsmash, ffms2, bestsource, or dgdecnv for SSIMULACRA2"
+        );
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn validate_butteraugli_inf(&self) -> anyhow::Result<()> {
+        ensure!(
+            self.vapoursynth_plugins.is_some_and(|p| p.vship)
+                || self.vapoursynth_plugins.is_some_and(|p| p.julek),
+            "Butteraugli metric requires either Vapoursynth-HIP or vapoursynth-julek-plugin to be \
+             installed"
+        );
+        ensure!(
+            matches!(
+                self.chunk_method,
+                ChunkMethod::LSMASH
+                    | ChunkMethod::FFMS2
+                    | ChunkMethod::BESTSOURCE
+                    | ChunkMethod::DGDECNV
+            ),
+            "Chunk method must be lsmash, ffms2, bestsource, or dgdecnv for Butteraugli"
+        );
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn validate_butteraugli_3(&self) -> anyhow::Result<()> {
+        ensure!(
+            self.vapoursynth_plugins.is_some_and(|p| p.vship),
+            "Butteraugli 3 Norm metric requires Vapoursynth-HIP plugin to be installed"
+        );
+        ensure!(
+            matches!(
+                self.chunk_method,
+                ChunkMethod::LSMASH
+                    | ChunkMethod::FFMS2
+                    | ChunkMethod::BESTSOURCE
+                    | ChunkMethod::DGDECNV
+            ),
+            "Chunk method must be lsmash, ffms2, bestsource, or dgdecnv for Butteraugli 3 Norm"
+        );
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn validate_xpsnr(&self, metric: TargetMetric, probing_rate: usize) -> anyhow::Result<()> {
+        let metric_name = if metric == TargetMetric::XPSNRWeighted {
+            "Weighted XPSNR"
+        } else {
+            "XPSNR"
+        };
+        if probing_rate > 1 {
+            ensure!(
+                self.vapoursynth_plugins.is_some_and(|p| p.vszip == VSZipVersion::New),
+                format!(
+                    "{metric_name} metric with probing rate greater than 1 requires \
+                     VapourSynth-Zig Image Process R7 or newer to be installed"
+                )
+            );
+            ensure!(
+                matches!(
+                    self.chunk_method,
+                    ChunkMethod::LSMASH
+                        | ChunkMethod::FFMS2
+                        | ChunkMethod::BESTSOURCE
+                        | ChunkMethod::DGDECNV
+                ),
+                format!(
+                    "Chunk method must be lsmash, ffms2, bestsource, or dgdecnv for {metric_name} \
+                     metric with probing rate greater than 1"
+                )
+            );
+        } else {
+            validate_libxpsnr()?;
+        }
+
+        Ok(())
     }
 }
 

--- a/av1an-core/src/zones.rs
+++ b/av1an-core/src/zones.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use anyhow::bail;
 
-use crate::{scenes::Scene, EncodeArgs};
+use crate::{metrics::vmaf::validate_libvmaf, scenes::Scene, EncodeArgs, TargetMetric};
 
 pub(crate) fn parse_zones(args: &EncodeArgs, frames: usize) -> anyhow::Result<Vec<Scene>> {
     let mut zones = Vec::new();
@@ -21,4 +21,91 @@ pub(crate) fn parse_zones(args: &EncodeArgs, frames: usize) -> anyhow::Result<Ve
         }
     }
     Ok(zones)
+}
+
+pub(crate) fn validate_zones(args: &EncodeArgs, zones: &[Scene]) -> anyhow::Result<()> {
+    if zones.is_empty() {
+        // No zones to validate
+        return Ok(());
+    }
+
+    // Using VMAF, validate libvmaf
+    if zones.iter().any(|zone| {
+        zone.zone_overrides
+            .as_ref()
+            .and_then(|ovr| ovr.target_quality.as_ref())
+            .and_then(|tq| tq.target.as_ref().filter(|_| tq.metric == TargetMetric::VMAF))
+            .is_some()
+    }) {
+        validate_libvmaf()?;
+    }
+
+    // Using SSIMULACRA2, validate SSIMULACRA2
+    if zones.iter().any(|zone| {
+        zone.zone_overrides
+            .as_ref()
+            .and_then(|ovr| ovr.target_quality.as_ref())
+            .and_then(|tq| tq.target.as_ref().filter(|_| tq.metric == TargetMetric::SSIMULACRA2))
+            .is_some()
+    }) {
+        args.validate_ssimululacra2()?;
+    }
+
+    // Using butteraugli-Inf, validate butteraugli-Inf
+    if zones.iter().any(|zone| {
+        zone.zone_overrides
+            .as_ref()
+            .and_then(|ovr| ovr.target_quality.as_ref())
+            .and_then(|tq| tq.target.as_ref().filter(|_| tq.metric == TargetMetric::ButteraugliINF))
+            .is_some()
+    }) {
+        args.validate_butteraugli_inf()?;
+    }
+
+    // Using butteraugli-3, validate butteraugli-3
+    if zones.iter().any(|zone| {
+        zone.zone_overrides
+            .as_ref()
+            .and_then(|ovr| ovr.target_quality.as_ref())
+            .and_then(|tq| tq.target.as_ref().filter(|_| tq.metric == TargetMetric::Butteraugli3))
+            .is_some()
+    }) {
+        args.validate_butteraugli_3()?;
+    }
+
+    // Using XPSNR and a probing rate > 1, validate XPSNR
+    if zones.iter().any(|zone| {
+        zone.zone_overrides
+            .as_ref()
+            .and_then(|ovr| ovr.target_quality.as_ref())
+            .and_then(|tq| {
+                tq.target.as_ref().filter(|_| {
+                    matches!(tq.metric, TargetMetric::XPSNR | TargetMetric::XPSNRWeighted)
+                        && tq.probing_rate > 1
+                })
+            })
+            .is_some()
+    }) {
+        // Any value greater than 1, uses VapourSynth
+        args.validate_xpsnr(TargetMetric::XPSNR, 2)?;
+    }
+
+    // Using XPSNR and a probing rate of 1, validate XPSNR
+    if zones.iter().any(|zone| {
+        zone.zone_overrides
+            .as_ref()
+            .and_then(|ovr| ovr.target_quality.as_ref())
+            .and_then(|tq| {
+                tq.target.as_ref().filter(|_| {
+                    matches!(tq.metric, TargetMetric::XPSNR | TargetMetric::XPSNRWeighted)
+                        && tq.probing_rate == 1
+                })
+            })
+            .is_some()
+    }) {
+        // 1, uses FFmpeg
+        args.validate_xpsnr(TargetMetric::XPSNR, 1)?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Resolves #1102

Target Metric VMAF is now only validated if the user supplies `--target-quality` or specifies at least 1 Zone where Target Quality is enabled. Zones are now validated after parsing so any issues with a specified Target Metric can be addressed in the new function.

I initially wanted to cache the validation as I planned to validate each Zone as it's parsed but instead went with parsing all Zones, then doing a filter check for the exact condition(s) that require validation. At worst, XPSNR could be validated up to 3 times, 2 for everything else. With the function only executing up to a maximum of 3 times, I decided to forgo complicating things with lazy loading and caching.

Thanks,
\- Boats M.