### PR TITLE
Fix VSPipe arguments are not passed to VapourSynth script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "av-decoders"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3e35d17e9df9c26170781708199dceb8baeb1bcd63e784a10c10d33ec4af67"
+checksum = "ce3eb4b0697edeafbbb6f15bcf22dde7ae7d8e7449211111a9bbb554862ed9a7"
 dependencies = [
  "num-rational",
  "thiserror 2.0.12",
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "av-scenechange"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6b9f8f5de6471673416c48d143210b225879ecbb0e7fb49dde1c004ced424"
+checksum = "5da809cb3aee6dac33f909ee9987ce6aafc91d7359386a03a048305fd1a66fcd"
 dependencies = [
  "aligned",
  "anyhow",

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -18,10 +18,10 @@ readme = "../README.md"
 [dependencies]
 anyhow = { workspace = true }
 arrayvec = "0.7.2"
-av-decoders = { version = "0.3.1", features = ["vapoursynth"] }
+av-decoders = { version = "0.4.0", features = ["vapoursynth"] }
 av-format = "0.7.0"
 av-ivf = "0.5.0"
-av-scenechange = { version = "0.17.2", default-features = false, features = [
+av-scenechange = { version = "0.17.3", default-features = false, features = [
     "vapoursynth",
 ] }
 av1-grain = { version = "0.2.4", default-features = false, features = [

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -204,7 +204,7 @@ impl Av1anContext {
                 Input::VapourSynth {
                     path, ..
                 } => {
-                    let dec = VapoursynthDecoder::from_file(path, Some(variables_map))?;
+                    let dec = VapoursynthDecoder::from_file(path, variables_map)?;
                     av_scenechange::Decoder::from_decoder_impl(
                         av_decoders::DecoderImpl::Vapoursynth(dec),
                     )?

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -800,7 +800,7 @@ impl Av1anContext {
                     let vs_script =
                         self.vs_script.as_ref().expect("vs_script should exist").as_path();
                     let vs_proxy_script = self.vs_proxy_script.as_deref();
-                    self.create_video_queue_vs(scenes, vs_script, vs_proxy_script, &Vec::new())?
+                    self.create_video_queue_vs(scenes, vs_script, vs_proxy_script, &[])?
                 },
                 ChunkMethod::Hybrid => self.create_video_queue_hybrid(scenes)?,
                 ChunkMethod::Select => self.create_video_queue_select(scenes)?,

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -204,8 +204,7 @@ impl Av1anContext {
                 Input::VapourSynth {
                     path, ..
                 } => {
-                    let mut dec = VapoursynthDecoder::from_file(path)?;
-                    dec.set_variables(variables_map)?;
+                    let dec = VapoursynthDecoder::from_file(path, Some(variables_map))?;
                     av_scenechange::Decoder::from_decoder_impl(
                         av_decoders::DecoderImpl::Vapoursynth(dec),
                     )?

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -814,7 +814,7 @@ impl Av1anContext {
                 scenes,
                 path.as_path(),
                 self.vs_proxy_script.as_deref(),
-                vspipe_args,
+                vspipe_args.iter().map(|arg| arg.as_str()).collect::<Vec<_>>().as_slice(),
             )?,
         };
 
@@ -946,7 +946,7 @@ impl Av1anContext {
         index: usize,
         vs_script: &Path,
         vs_proxy_script: Option<&Path>,
-        vspipe_args: &Vec<String>,
+        vspipe_args: &[&str],
         scene: &Scene,
         frame_rate: f64,
     ) -> anyhow::Result<Chunk> {
@@ -956,7 +956,7 @@ impl Av1anContext {
 
         fn gen_vspipe_cmd(
             vs_script: &Path,
-            vs_args: &Vec<String>,
+            vs_args: &[&str],
             scene_start: usize,
             scene_end: usize,
         ) -> Vec<OsString> {
@@ -1064,7 +1064,7 @@ impl Av1anContext {
         scenes: &[Scene],
         vs_script: &Path,
         vs_proxy_script: Option<&Path>,
-        vspipe_args: &Vec<String>,
+        vspipe_args: &[&str],
     ) -> anyhow::Result<Vec<Chunk>> {
         let frame_rate = self
             .args

--- a/av1an-core/src/context.rs
+++ b/av1an-core/src/context.rs
@@ -215,7 +215,7 @@ impl Av1anContext {
                         self.args.sc_pix_format,
                         Some(&self.args.scaler),
                     )?,
-                    Some(variables_map),
+                    variables_map,
                 )?,
             };
             // Getting the details will evaluate the script and produce the VapourSynth

--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -247,8 +247,10 @@ fn build_decoder(
 
         // Must use from_file in order to set the CWD to the
         // directory of the user-provided VapourSynth script
-        let mut vs_decoder = VapoursynthDecoder::from_file(input.as_vapoursynth_path())?;
-        vs_decoder.set_variables(input.as_vspipe_args_hashmap()?)?;
+        let mut vs_decoder = VapoursynthDecoder::from_file(
+            input.as_vapoursynth_path(),
+            input.as_vspipe_args_hashmap()?,
+        )?;
 
         if sc_downscale_height.is_some() || sc_pix_format.is_some() {
             let downscale_height = sc_downscale_height.map(|dh| dh as u32);

--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -1158,7 +1158,7 @@ mod tests {
                 scores.iter().min_by(|(q1, _), (q2, _)| {
                     ((*q1 - next_quantizer).abs())
                         .partial_cmp(&((*q2 - next_quantizer).abs()))
-                        .unwrap()
+                        .expect("partial_cmp should succeed")
                 }) {
                 *closest_q
             } else {


### PR DESCRIPTION
Resolves #1097

Bump av-decoders from 0.3.1 to 0.4.0
Bump av-scenechange from 0.17.2 to 0.17.3

~~These are predicted versions. If a different version is released I'll update the PR(s).~~ Done.

~~Requires both rust-av/av-decoders#4 and rust-av/av-scenechange#192 to be merged and released before merging this PR.~~ Done and Cargo.lock updated, thanks.

Thanks,
\- Boats M.