### PR TITLE
Bugfix: Exit target quality if bounds are meet

### DIFF
--- a/av1an-core/src/target_quality.rs
+++ b/av1an-core/src/target_quality.rs
@@ -256,7 +256,7 @@ impl TargetQuality {
             }
 
             // Ensure quantizer limits are valid
-            if lower_quantizer_limit > upper_quantizer_limit {
+            if lower_quantizer_limit >= upper_quantizer_limit {
                 log_probes(
                     &quantizer_score_history,
                     self.metric,


### PR DESCRIPTION
From Discord discussion. 

Av1an can underflow the min q values when a lot of probes are used, and the target metric fails to reach the desired quality even at low. 