### PR TITLE
Sleep Guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,12 +256,15 @@ dependencies = [
  "av1-grain",
  "cfg-if",
  "colored",
+ "core-foundation",
  "crossbeam-channel",
  "crossbeam-utils",
  "ctrlc",
  "dashmap",
+ "dbus",
  "indicatif",
  "itertools",
+ "libc",
  "memchr",
  "nom 8.0.0",
  "num-traits",
@@ -284,6 +287,7 @@ dependencies = [
  "tracing",
  "vapoursynth",
  "which",
+ "windows",
  "y4m",
 ]
 
@@ -461,6 +465,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +581,17 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
  "serde",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -973,6 +1004,15 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -2181,9 +2221,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.1"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
  "windows-core",
@@ -2249,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-numerics"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
  "tracing",
  "vapoursynth",
  "which",
- "windows",
+ "windows-sys 0.60.2",
  "y4m",
 ]
 

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -74,6 +74,16 @@ regex = "1.11.1"
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
 affinity = "0.1.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+dbus = "0.9"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61.3", features = ["Win32_System_Power"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10.1"
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/av1an-core/Cargo.toml
+++ b/av1an-core/Cargo.toml
@@ -78,7 +78,7 @@ affinity = "0.1.2"
 dbus = "0.9"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.61.3", features = ["Win32_System_Power"] }
+windows-sys = { version = "0.60.2", features = ["Win32_System_Power"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10.1"

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -57,6 +57,7 @@ mod progress_bar;
 mod scene_detect;
 mod scenes;
 mod settings;
+pub mod sleep_guard;
 mod split;
 mod target_quality;
 mod util;

--- a/av1an-core/src/sleep_guard.rs
+++ b/av1an-core/src/sleep_guard.rs
@@ -1,5 +1,18 @@
+//! Cross-platform sleep inhibition guard (maximized safety).
+//
+//! This module exposes a small RAII guard that prevents the system (or just
+//! the idle subsystem) from going to sleep while it is alive.
+//
+//! Platforms:
+//! - Linux: uses logind's `Inhibit` D-Bus API (org.freedesktop.login1).
+//!   Stores `dbus::arg::OwnedFd` directly — no raw-FD manipulation.
+//! - Windows: uses `SetThreadExecutionState` (small FFI call in a tight unsafe block).
+//! - macOS: uses `IOPMAssertionCreateWithName` (tight unsafe FFI, CFStrings created safely).
+//
+//! Drop the guard to release the inhibition.
+
 /// What to keep awake.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum Scope {
     /// Block system sleep (idle suspend). On Linux this maps to `"sleep"`;
     /// on macOS this uses a system/idle assertion; on Windows it sets
@@ -10,56 +23,69 @@ pub enum Scope {
     IdleOnly,
 }
 
+/// RAII guard that holds a platform-specific sleep inhibition.
 #[must_use = "dropping this guard releases the sleep inhibition"]
-pub struct SleepGuard { _guard: PlatformGuard }
+pub struct SleepGuard {
+    _guard: PlatformGuard,
+}
 
-impl SleepGuard
-{
+impl SleepGuard {
+    /// Acquire a system sleep inhibitor.
+    ///
+    /// `app` is the application name presented to the OS, and `why` is a human
+    /// readable reason.
     #[inline]
     pub fn acquire(scope: Scope, app: &str, why: &str) -> anyhow::Result<Self> {
-        Ok(Self { _guard: PlatformGuard::acquire(scope, app, why)? })    }
-}
+        Ok(Self {
+            _guard: PlatformGuard::acquire(scope, app, why)?,
+        })
+    }
 
-enum PlatformGuard {
-    #[cfg(target_os = "linux")]
-    Linux(#[allow(dead_code)]  LinuxGuard),
-    #[cfg(target_os = "windows")]
-    Windows(#[allow(dead_code)] WindowsGuard),
-    #[cfg(target_os = "macos")]
-    Mac(#[allow(dead_code)] MacGuard),
-}
-
-impl PlatformGuard {
-    fn acquire(scope: Scope, app: &str, why: &str) -> anyhow::Result<Self> {
-        #[cfg(target_os = "linux")]
-        {
-            return Ok(Self::Linux(LinuxGuard::new(scope, app, why)?));
-        }
-        #[cfg(target_os = "windows")]
-        {
-            return Ok(Self::Windows(WindowsGuard::new(scope)?));
-        }
-        #[cfg(target_os = "macos")]
-        {
-            return Ok(Self::Mac(MacGuard::new(scope, app, why)?));
-        }
-        #[allow(unreachable_code)]
-        Err(anyhow::Error::msg("Unsupported platform"))
+    /// Acquire using a default app name (the current executable name) and a generic reason.
+    #[inline]
+    pub fn acquire_default(scope: Scope) -> anyhow::Result<Self> {
+        let app = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()))
+            .unwrap_or_else(|| "app".into());
+        Self::acquire(scope, &app, "prevent system sleep")
     }
 }
 
-// --------------------------- Linux (systemd/logind) ------------------------
+/// Platform-specific guard.
+enum PlatformGuard {
+    #[cfg(target_os = "linux")]
+    Linux(#[allow(dead_code)] linux_impl::LinuxGuard),
+    #[cfg(target_os = "windows")]
+    Windows(#[allow(dead_code)] windows_impl::WindowsGuard),
+    #[cfg(target_os = "macos")]
+    Mac(#[allow(dead_code)] mac_impl::MacGuard),
+}
+
+impl PlatformGuard {
+    #[inline]
+    fn acquire(scope: Scope, app: &str, why: &str) -> anyhow::Result<Self> {
+        #[cfg(target_os = "linux")]
+        { return Ok(Self::Linux(linux_impl::LinuxGuard::new(scope, app, why)?)); }
+        #[cfg(target_os = "windows")]
+        { return Ok(Self::Windows(windows_impl::WindowsGuard::new(scope, app, why)?)); }
+        #[cfg(target_os = "macos")]
+        { return Ok(Self::Mac(mac_impl::MacGuard::new(scope, app, why)?)); }
+
+        #[allow(unreachable_code)]
+        Err(anyhow::anyhow!("unsupported platform"))
+    }
+}
 
 #[cfg(target_os = "linux")]
 mod linux_impl {
-    use std::{fs::File, os::unix::io::FromRawFd};
-
     use dbus::{arg::OwnedFd, blocking::Connection};
-
     use super::*;
 
+    /// Holds the D-Bus-owned inhibition file descriptor.
+    /// The FD is closed automatically when this value is dropped.
     pub struct LinuxGuard {
-        _fd_holder: File,
+        _fd: OwnedFd,
     }
 
     impl LinuxGuard {
@@ -71,104 +97,89 @@ mod linux_impl {
                 std::time::Duration::from_secs(5),
             );
 
-            // "sleep" blocks suspend; "idle" blocks idle actions (like display off)
-            let kind = match scope {
+            let what = match scope {
                 Scope::System => "sleep",
                 Scope::IdleOnly => "idle",
             };
 
-            let (owned_fd,): (OwnedFd,) = proxy.method_call(
+            // Call Inhibit(what, who, why, mode) -> unix fd (OwnedFd closes on drop).
+            let (fd,): (OwnedFd,) = proxy.method_call(
                 "org.freedesktop.login1.Manager",
                 "Inhibit",
-                (kind, app_name, reason, "block"),
+                (what, app_name, reason, "block"),
             )?;
 
-            let raw_fd = owned_fd.into_fd();
-            // SAFETY: `owned_fd` was just converted via `into_fd()`. We take exclusive ownership by
-            // wrapping it in `File`, and we do not use `raw_fd` again after this point.
-            let fd_holder = unsafe { File::from_raw_fd(raw_fd) };
-            Ok(Self {
-                _fd_holder: fd_holder,
-            })
+            Ok(Self { _fd: fd })
         }
     }
 }
 
-#[cfg(target_os = "linux")]
-use linux_impl::LinuxGuard;
-
-// ------------------------------- Windows -----------------------------------
-
 #[cfg(target_os = "windows")]
 mod windows_impl {
-    use windows::Win32::System::Power::{
-        SetThreadExecutionState,
-        ES_CONTINUOUS,
-        ES_SYSTEM_REQUIRED,
-        EXECUTION_STATE,
-    };
-
     use super::*;
 
-    pub struct WindowsGuard {
-        _flags: EXECUTION_STATE,
-    }
+    pub struct WindowsGuard;
 
     impl WindowsGuard {
-        pub fn new(scope: Scope) -> anyhow::Result<Self> {
-            let mut flags = ES_CONTINUOUS;
-            if matches!(scope, Scope::System) {
-                flags |= ES_SYSTEM_REQUIRED;
+        pub fn new(scope: Scope, _app: &str, _reason: &str) -> anyhow::Result<Self> {
+            // Map scope to execution state flags.
+            // ES_CONTINUOUS is always set to make the request sticky for this call.
+            const ES_CONTINUOUS: u32 = 0x80000000;
+            const ES_SYSTEM_REQUIRED: u32 = 0x00000001;
+            const ES_DISPLAY_REQUIRED: u32 = 0x00000002;
+
+            let mut flags: u32 = ES_CONTINUOUS;
+            match scope {
+                Scope::System => { flags |= ES_SYSTEM_REQUIRED; }
+                Scope::IdleOnly => { flags |= ES_DISPLAY_REQUIRED; }
             }
 
-            let prev = unsafe { SetThreadExecutionState(flags) };
-            if prev.0 == 0 {
+            // SAFETY: Calling documented Windows API with constant flags.
+            let prev = unsafe { windows_sys::Win32::System::Power::SetThreadExecutionState(flags) };
+            if prev == 0 {
                 return Err(anyhow::anyhow!("SetThreadExecutionState failed"));
             }
-            Ok(Self {
-                _flags: flags
-            })
+            Ok(Self)
         }
     }
 
     impl Drop for WindowsGuard {
         fn drop(&mut self) {
-            unsafe {
-                let _ = SetThreadExecutionState(ES_CONTINUOUS);
-            }
+            // Clear the requirement and keep ES_CONTINUOUS.
+            const ES_CONTINUOUS: u32 = 0x80000000;
+            // SAFETY: Restoring to a benign state.
+            unsafe { windows_sys::Win32::System::Power::SetThreadExecutionState(ES_CONTINUOUS); }
         }
     }
 }
-#[cfg(target_os = "windows")]
-use windows_impl::WindowsGuard;
-
-// -------------------------------- macOS ------------------------------------
 
 #[cfg(target_os = "macos")]
 mod mac_impl {
-    use core_foundation::{base::TCFType, string::CFString};
-    use libc::{c_int, c_uint};
-
     use super::*;
 
-    // Types from IOKit/IOPMLib.h
-    type IOPMAssertionID = c_uint;
-    type IOPMAssertionLevel = c_uint;
-    type IOReturn = c_int;
-
-    // kIOPMAssertionLevelOn == 255
-    const K_IOPM_ASSERTION_LEVEL_ON: IOPMAssertionLevel = 255;
+    #[allow(non_camel_case_types)]
+    type IOReturn = i32;
+    #[allow(non_camel_case_types)]
+    type IOPMAssertionID = u32;
+    #[allow(non_camel_case_types)]
+    type CFStringRef = *const std::ffi::c_void;
 
     #[link(name = "IOKit", kind = "framework")]
     extern "C" {
         fn IOPMAssertionCreateWithName(
-            assertion_type: *const std::ffi::c_void, // CFStringRef
-            level: IOPMAssertionLevel,
-            assertion_name: *const std::ffi::c_void, // CFStringRef
-            out_id: *mut IOPMAssertionID,
+            assertion_type: CFStringRef,
+            level: u32,
+            assertion_name: CFStringRef,
+            assertion_id: *mut IOPMAssertionID,
         ) -> IOReturn;
+        fn IOPMAssertionRelease(assertion_id: IOPMAssertionID) -> IOReturn;
+    }
 
-        fn IOPMAssertionRelease(id: IOPMAssertionID) -> IOReturn;
+    fn cfstr(s: &str) -> *const std::ffi::c_void {
+        use core_foundation::string::CFString;
+        use core_foundation::base::TCFType;
+        let cf = CFString::new(s);
+        cf.as_concrete_TypeRef() as *const std::ffi::c_void
     }
 
     pub struct MacGuard {
@@ -176,45 +187,34 @@ mod mac_impl {
     }
 
     impl MacGuard {
-        pub fn new(scope: Scope, app_name: &str, reason: &str) -> anyhow::Result<Self> {
-            // Apple’s constants are CFStringRefs with these literal contents:
-            //  - "PreventUserIdleSystemSleep"   (prevents idle system sleep)
-            //  - "NoIdleSleep"                  (stronger; rarely needed)
-            let name = CFString::new(&format!("{app_name}: {reason}"));
-
-            // Primary assertion: prevent idle system sleep if Scope::System, otherwise just
-            // idle cases.
-            let typ = match scope {
-                Scope::System => CFString::from_static_string("PreventUserIdleSystemSleep"),
-                Scope::IdleOnly => CFString::from_static_string("PreventUserIdleSystemSleep"),
+        pub fn new(scope: Scope, _app: &str, why: &str) -> anyhow::Result<Self> {
+            // Map scope to IOPM assertion type.
+            let assertion_type = match scope {
+                Scope::System => "NoIdleSleepAssertion",
+                Scope::IdleOnly => "NoDisplaySleepAssertion",
             };
 
             let mut id: IOPMAssertionID = 0;
-            let rc = unsafe {
+            // SAFETY: FFI call with well-formed CFStrings that live across the call.
+            let ret = unsafe {
                 IOPMAssertionCreateWithName(
-                    typ.as_concrete_TypeRef() as _,
-                    K_IOPM_ASSERTION_LEVEL_ON,
-                    name.as_concrete_TypeRef() as _,
-                    &mut id as *mut _,
+                    cfstr(assertion_type),
+                    255, // kIOPMAssertionLevelOn
+                    cfstr(why),
+                    &mut id,
                 )
             };
-            if rc != 0 {
-                return Err(anyhow::anyhow!("IOPMAssertionCreateWithName failed: {rc}"));
+            if ret != 0 {
+                return Err(anyhow::anyhow!("IOPMAssertionCreateWithName failed: {}", ret));
             }
-
-            Ok(Self {
-                id,
-            })
+            Ok(Self { id })
         }
     }
 
     impl Drop for MacGuard {
         fn drop(&mut self) {
-            unsafe {
-                let _ = IOPMAssertionRelease(self.id);
-            }
+            // SAFETY: Releasing a valid assertion id is defined.
+            unsafe { let _ = IOPMAssertionRelease(self.id); }
         }
     }
 }
-#[cfg(target_os = "macos")]
-use mac_impl::MacGuard;

--- a/av1an-core/src/sleep_guard.rs
+++ b/av1an-core/src/sleep_guard.rs
@@ -1,0 +1,220 @@
+/// What to keep awake.
+#[derive(Debug, Clone, Copy)]
+pub enum Scope {
+    /// Block system sleep (idle suspend). On Linux this maps to `"sleep"`;
+    /// on macOS this uses a system/idle assertion; on Windows it sets
+    /// `ES_SYSTEM_REQUIRED`.
+    System,
+    /// Block *idle* actions only (no suspend; mostly screen blank, idle sleep).
+    /// On Linux this maps to `"idle"`.
+    IdleOnly,
+}
+
+#[must_use = "dropping this guard releases the sleep inhibition"]
+pub struct SleepGuard { _guard: PlatformGuard }
+
+impl SleepGuard
+{
+    #[inline]
+    pub fn acquire(scope: Scope, app: &str, why: &str) -> anyhow::Result<Self> {
+        Ok(Self { _guard: PlatformGuard::acquire(scope, app, why)? })    }
+}
+
+enum PlatformGuard {
+    #[cfg(target_os = "linux")]
+    Linux(#[allow(dead_code)]  LinuxGuard),
+    #[cfg(target_os = "windows")]
+    Windows(#[allow(dead_code)] WindowsGuard),
+    #[cfg(target_os = "macos")]
+    Mac(#[allow(dead_code)] MacGuard),
+}
+
+impl PlatformGuard {
+    fn acquire(scope: Scope, app: &str, why: &str) -> anyhow::Result<Self> {
+        #[cfg(target_os = "linux")]
+        {
+            return Ok(Self::Linux(LinuxGuard::new(scope, app, why)?));
+        }
+        #[cfg(target_os = "windows")]
+        {
+            return Ok(Self::Windows(WindowsGuard::new(scope)?));
+        }
+        #[cfg(target_os = "macos")]
+        {
+            return Ok(Self::Mac(MacGuard::new(scope, app, why)?));
+        }
+        #[allow(unreachable_code)]
+        Err(anyhow::Error::msg("Unsupported platform"))
+    }
+}
+
+// --------------------------- Linux (systemd/logind) ------------------------
+
+#[cfg(target_os = "linux")]
+mod linux_impl {
+    use std::{fs::File, os::unix::io::FromRawFd};
+
+    use dbus::{arg::OwnedFd, blocking::Connection};
+
+    use super::*;
+
+    pub struct LinuxGuard {
+        _fd_holder: File,
+    }
+
+    impl LinuxGuard {
+        pub fn new(scope: Scope, app_name: &str, reason: &str) -> anyhow::Result<Self> {
+            let conn = Connection::new_system()?;
+            let proxy = conn.with_proxy(
+                "org.freedesktop.login1",
+                "/org/freedesktop/login1",
+                std::time::Duration::from_secs(5),
+            );
+
+            // "sleep" blocks suspend; "idle" blocks idle actions (like display off)
+            let kind = match scope {
+                Scope::System => "sleep",
+                Scope::IdleOnly => "idle",
+            };
+
+            let (owned_fd,): (OwnedFd,) = proxy.method_call(
+                "org.freedesktop.login1.Manager",
+                "Inhibit",
+                (kind, app_name, reason, "block"),
+            )?;
+
+            let raw_fd = owned_fd.into_fd();
+            // SAFETY: `owned_fd` was just converted via `into_fd()`. We take exclusive ownership by
+            // wrapping it in `File`, and we do not use `raw_fd` again after this point.
+            let fd_holder = unsafe { File::from_raw_fd(raw_fd) };
+            Ok(Self {
+                _fd_holder: fd_holder,
+            })
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+use linux_impl::LinuxGuard;
+
+// ------------------------------- Windows -----------------------------------
+
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use windows::Win32::System::Power::{
+        SetThreadExecutionState,
+        ES_CONTINUOUS,
+        ES_SYSTEM_REQUIRED,
+        EXECUTION_STATE,
+    };
+
+    use super::*;
+
+    pub struct WindowsGuard {
+        _flags: EXECUTION_STATE,
+    }
+
+    impl WindowsGuard {
+        pub fn new(scope: Scope) -> anyhow::Result<Self> {
+            let mut flags = ES_CONTINUOUS;
+            if matches!(scope, Scope::System) {
+                flags |= ES_SYSTEM_REQUIRED;
+            }
+
+            let prev = unsafe { SetThreadExecutionState(flags) };
+            if prev.0 == 0 {
+                return Err(anyhow::anyhow!("SetThreadExecutionState failed"));
+            }
+            Ok(Self {
+                _flags: flags
+            })
+        }
+    }
+
+    impl Drop for WindowsGuard {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = SetThreadExecutionState(ES_CONTINUOUS);
+            }
+        }
+    }
+}
+#[cfg(target_os = "windows")]
+use windows_impl::WindowsGuard;
+
+// -------------------------------- macOS ------------------------------------
+
+#[cfg(target_os = "macos")]
+mod mac_impl {
+    use core_foundation::{base::TCFType, string::CFString};
+    use libc::{c_int, c_uint};
+
+    use super::*;
+
+    // Types from IOKit/IOPMLib.h
+    type IOPMAssertionID = c_uint;
+    type IOPMAssertionLevel = c_uint;
+    type IOReturn = c_int;
+
+    // kIOPMAssertionLevelOn == 255
+    const K_IOPM_ASSERTION_LEVEL_ON: IOPMAssertionLevel = 255;
+
+    #[link(name = "IOKit", kind = "framework")]
+    extern "C" {
+        fn IOPMAssertionCreateWithName(
+            assertion_type: *const std::ffi::c_void, // CFStringRef
+            level: IOPMAssertionLevel,
+            assertion_name: *const std::ffi::c_void, // CFStringRef
+            out_id: *mut IOPMAssertionID,
+        ) -> IOReturn;
+
+        fn IOPMAssertionRelease(id: IOPMAssertionID) -> IOReturn;
+    }
+
+    pub struct MacGuard {
+        id: IOPMAssertionID,
+    }
+
+    impl MacGuard {
+        pub fn new(scope: Scope, app_name: &str, reason: &str) -> anyhow::Result<Self> {
+            // Apple’s constants are CFStringRefs with these literal contents:
+            //  - "PreventUserIdleSystemSleep"   (prevents idle system sleep)
+            //  - "NoIdleSleep"                  (stronger; rarely needed)
+            let name = CFString::new(&format!("{app_name}: {reason}"));
+
+            // Primary assertion: prevent idle system sleep if Scope::System, otherwise just
+            // idle cases.
+            let typ = match scope {
+                Scope::System => CFString::from_static_string("PreventUserIdleSystemSleep"),
+                Scope::IdleOnly => CFString::from_static_string("PreventUserIdleSystemSleep"),
+            };
+
+            let mut id: IOPMAssertionID = 0;
+            let rc = unsafe {
+                IOPMAssertionCreateWithName(
+                    typ.as_concrete_TypeRef() as _,
+                    K_IOPM_ASSERTION_LEVEL_ON,
+                    name.as_concrete_TypeRef() as _,
+                    &mut id as *mut _,
+                )
+            };
+            if rc != 0 {
+                return Err(anyhow::anyhow!("IOPMAssertionCreateWithName failed: {rc}"));
+            }
+
+            Ok(Self {
+                id,
+            })
+        }
+    }
+
+    impl Drop for MacGuard {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = IOPMAssertionRelease(self.id);
+            }
+        }
+    }
+}
+#[cfg(target_os = "macos")]
+use mac_impl::MacGuard;

--- a/av1an-core/src/sleep_guard.rs
+++ b/av1an-core/src/sleep_guard.rs
@@ -10,7 +10,7 @@
 //!   block).
 //! - macOS: uses `IOPMAssertionCreateWithName` (tight unsafe FFI, CFStrings
 //!   created safely).
-//
+//!
 //! Drop the guard to release the inhibition.
 
 /// What to keep awake.

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -13,6 +13,7 @@ use av1an_core::{
     hash_path,
     into_vec,
     read_in_dir,
+    sleep_guard::{Scope, SleepGuard},
     vapoursynth::{get_vapoursynth_plugins, VSZipVersion},
     Av1anContext,
     ChunkMethod,
@@ -1225,6 +1226,10 @@ pub fn run() -> anyhow::Result<()> {
     )?;
 
     let args = parse_cli(cli_options)?;
+
+    // enable keep awake during encodes
+    let _guard = SleepGuard::acquire(Scope::System, "av1an", "Encoding video")?;
+
     for arg in args {
         Av1anContext::new(arg)?.encode_file()?;
     }

--- a/av1an/src/main.rs
+++ b/av1an/src/main.rs
@@ -13,7 +13,7 @@ use av1an_core::{
     hash_path,
     into_vec,
     read_in_dir,
-    sleep_guard::{Scope, SleepGuard},
+    sleep_guard::SleepGuard,
     vapoursynth::{get_vapoursynth_plugins, VSZipVersion},
     Av1anContext,
     ChunkMethod,
@@ -1228,7 +1228,18 @@ pub fn run() -> anyhow::Result<()> {
     let args = parse_cli(cli_options)?;
 
     // enable keep awake during encodes
-    let _guard = SleepGuard::acquire(Scope::System, "av1an", "Encoding video")?;
+    let mut _guard;
+    match SleepGuard::acquire("av1an", "Encoding video") {
+        Ok(guard) => {
+            _guard = guard;
+        },
+        Err(e) => {
+            println!(
+                "Failed to inhibit sleep: {}. Continuing without sleep inhibition.",
+                e
+            );
+        },
+    }
 
     for arg in args {
         Av1anContext::new(arg)?.encode_file()?;


### PR DESCRIPTION
I had the problem, that av1an encodes would not run through overnight, as my system would simply go into sleep - even though an encoding job was already running. In my case that would be Arch Linux. It seems like other people have this issue as well, see #889.

This PR ads a sleep guard to av1an that should prevent sleeping while an encode is running. I first tried to use the suggested crate [keepawake](https://docs.rs/keepawake/latest/keepawake/) as suggested in the Issue, but it pulled far more dependencies as expected, which were also outdated. 

I sat down to write implementations for linux, windows and macOS myself, that should prevent the system from going into sleep.

I have tested the linux and the windows implementations. The macOS implementation is untested, as I was not able to get av1an to start an encoding job there. 

Screenshot Linux (KDE Plasma):
<img width="575" height="575" alt="image" src="https://github.com/user-attachments/assets/699663a4-8da3-4367-b1a8-0694f36e1938" />

Screenshot Windows 10:
<img width="652" height="441" alt="Unbenannt" src="https://github.com/user-attachments/assets/a0dc5b1a-eec0-4ffe-ad0e-ce865a2b9673" />
