### PR TITLE
fix: remove git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.y4m filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Although git lfs would be ideal for storing the y4m file used in the integration tests, it is a pain in the rear. In addition to the additional cloning steps required, it is apparently breaking the AUR package for av1an-git. Therefore, removing it seems to be the simplest way forward.