### PR TITLE
Fix Scene Detection Scores are overwriting previous Zones

### DIFF
--- a/av1an-core/src/scene_detect.rs
+++ b/av1an-core/src/scene_detect.rs
@@ -179,7 +179,7 @@ pub fn scene_detect(
                 );
             }
         }
-        scores.extend(&sc_result.scores);
+        scores.extend(sc_result.scores.iter().map(|(k, v)| (k + frames_read, *v)));
 
         let scene_changes = sc_result.scene_changes;
         for (start, end) in scene_changes.iter().copied().tuple_windows() {


### PR DESCRIPTION
Resolves #1107

When the `BTreeMap` is filled out during Scene Detection, it does not account for the number of frames that have already been read before evaluating the current Zone. When Zones are provided by the user and the `loop` runs multiple times for each Zone, the `BTreeMap` is extended with the Scores (per frame) of the detected Scene but the Scores always start at 0 instead of the absolute frame index of the original video. This means each Zone will overwrite the keys of the previous Zones leading to erroneous results and inaccurate enhanced-extra-splits. This PR maps the keys such that they are offset to the absolute frame index before being extended into the final `BTreeMap`.

With the `BTreeMap` correctly extended, the original Issue should no longer occur as frames are no longer missing scores and can be evaluated in `enhanced_extra_splits`.

Thanks,
\- Boats McGee