### PR TITLE
chore: add rust-toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-09-01"
+components = ["rustfmt"]


### PR DESCRIPTION
Since av1an uses nightly-only formatting options, a nightly rustc is required for having changes merged. Shipping a rust-toolchain file specifying a compatible nightly build will make it easier for rustup users to contribute to av1an.